### PR TITLE
Fix leadearboard showing on load

### DIFF
--- a/src/views/Game.vue
+++ b/src/views/Game.vue
@@ -260,8 +260,8 @@ export default {
       this.$router.push(location);
     },
     everyoneGuessed: function() {
-      if (!this.players) return false;
-      if (!this.guesses) return false;
+      if (Object.keys(this.players).length == 0) return false;
+      if (Object.keys(this.guesses).length == 0) return false;
       for (const player_uuid in this.players) {
         if (!(player_uuid in this.guesses)) return false;
       }


### PR DESCRIPTION
This fixes the situation where the empty leaderboard flashes on the screen during loading if no players are loaded yet.

this.players and this.guesses are not JavaScript objects actually holding players but an Observer object that facilitates the "reactive" behaviour of the app. Thus, they are always non-empty. Checking explicitly for "keys" fixes the problem and the leaderboard shows only when actually all players have guessed.

Fixes #11 