### PR TITLE
Maybe fix the evil overlay

### DIFF
--- a/src/views/Game.vue
+++ b/src/views/Game.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="game-view-container">
-    <v-overlay v-show="everyoneGuessed()">
+    <v-overlay :value="everyoneGuessed()">
       <v-card light>
         <Leaderboard
           v-bind:players="players"


### PR DESCRIPTION
I am not completely sure why this helps, nor why it used v-show instead of value before but it seems to help - at least it stops reproducing on dev server.

My guess is that the previous version triggered some kind of race condition, potentially not in our code but in the framework, but :value is evaluated differently and fixes the problem.

Issue #20 