### PR TITLE
Improve leaderboard UI

### DIFF
--- a/src/components/Leaderboard.vue
+++ b/src/components/Leaderboard.vue
@@ -1,8 +1,5 @@
 <template>
   <v-container>
-    <v-card-title>
-      Leaderboard
-    </v-card-title>
     <v-card-text>
       <v-simple-table dense>
         <thead>

--- a/src/components/RoundStatus.vue
+++ b/src/components/RoundStatus.vue
@@ -1,11 +1,15 @@
 <template>
-  <v-card-text>
-    <div
-      style="width: 800px; height: 800px; position: fixed; left: 0; right: 0;"
-      id="round-summary-map-anchor"
-    />
-  </v-card-text>
+  <div id="round-summary-map-anchor" />
 </template>
+<style scoped>
+#round-summary-map-anchor {
+  position: fixed;
+  width: 35vw;
+  height: 75vh;
+  overflow: hidden;
+  max-height: calc(90vh - 150px);
+}
+</style>
 
 <script>
 /*global google*/

--- a/src/views/Game.vue
+++ b/src/views/Game.vue
@@ -24,16 +24,20 @@
             </v-col>
           </v-row>
         </v-container>
-        <v-card-actions v-if="isChief()" class="card-bottom">
-          <v-spacer></v-spacer>
+        <v-card-actions v-if="isNotLastRound()" class="card-bottom">
           <v-btn
             class="white--text"
             color="accent"
-            v-if="isNotLastRound()"
+            v-if="isChief()"
             v-on:click="nextround()"
           >
             Next round!
           </v-btn>
+          <v-card-text v-if="!isChief()">
+            <div class="font-weight-light font-italic">
+              Waiting for {{ chiefName }} to start next round...
+            </div>
+          </v-card-text>
         </v-card-actions>
       </v-card>
     </v-overlay>
@@ -178,6 +182,11 @@ export default {
           });
         }
       });
+  },
+  computed: {
+    chiefName: function() {
+      return this.players[this.currentChief].username;
+    },
   },
   methods: {
     refreshPage: function() {

--- a/src/views/Game.vue
+++ b/src/views/Game.vue
@@ -1,19 +1,30 @@
 <template>
   <div id="game-view-container">
-    <v-overlay :value="everyoneGuessed()">
-      <v-card light>
-        <Leaderboard
-          v-bind:players="players"
-          v-bind:roundSummaries="roundSummaries"
-          v-bind:roundsSize="roundsSize"
-        />
-        <RoundStatus
-          v-bind:players="players"
-          v-bind:guesses="guesses"
-          v-bind:mapPosition="mapPosition"
-          v-bind:summary="currentSummary"
-        />
-        <v-card-actions v-if="isChief()">
+    <v-overlay :value="everyoneGuessed()" id="leaderboard-overlay">
+      <v-card light height="100%">
+        <v-card-title>
+          Leaderboard
+        </v-card-title>
+        <v-container>
+          <v-row no-gutters style="height: 80vh">
+            <v-col cols="6">
+              <Leaderboard
+                v-bind:players="players"
+                v-bind:roundSummaries="roundSummaries"
+                v-bind:roundsSize="roundsSize"
+              />
+            </v-col>
+            <v-col cols="6">
+              <RoundStatus
+                v-bind:players="players"
+                v-bind:guesses="guesses"
+                v-bind:mapPosition="mapPosition"
+                v-bind:summary="currentSummary"
+              />
+            </v-col>
+          </v-row>
+        </v-container>
+        <v-card-actions v-if="isChief()" class="card-bottom">
           <v-spacer></v-spacer>
           <v-btn
             class="white--text"
@@ -71,6 +82,17 @@
 #map-overlay:hover {
   width: 90%;
   height: 90%;
+}
+
+#leaderboard-overlay >>> .v-overlay__content {
+  width: 80vw;
+  height: 90vh;
+}
+
+.card-bottom {
+  position: absolute;
+  bottom: 0;
+  right: 0;
 }
 </style>
 


### PR DESCRIPTION
Move the leaderboard UI to a more vertical setup (the table on the left, the map on the right) and constrain the sizes to fit on smaller screens as well.
Also, add a text for people who do not have "Next round" button, indicating who can start the next round.

Fixes #22