### PR TITLE
Run refreshMarkers explicitly on mount

### DIFF
--- a/src/components/RoundStatus.vue
+++ b/src/components/RoundStatus.vue
@@ -81,9 +81,7 @@ export default {
 
       this.markers = [];
     },
-  },
-  watch: {
-    player_ready_list: function() {
+    refreshMarkers: function() {
       this.wipeMarkers();
       this.mountMap();
 
@@ -128,9 +126,15 @@ export default {
       }
     },
   },
+  watch: {
+    player_ready_list: function() {
+      this.refreshMarkers();
+    },
+  },
   mounted: function() {
     this.wipeMarkers();
     this.mountMap();
+    this.refreshMarkers();
   },
 };
 </script>


### PR DESCRIPTION
Otherwise, it is not run for the last user to guess.

It worked before the fix for "blinking" leaderboard at the beginning of the round. Now RoundStatus is probably created/mounted only as the leaderboard is shown, so it can't catch any updates as nothing changed since it was created.