### PR TITLE
Add optional jump buttons to the streetview component, establish a method for the current player location to be communicated to the parent

### DIFF
--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -10,6 +10,40 @@
     >
       <v-icon large>mdi-anchor</v-icon>
     </v-btn>
+    <v-container v-if="jumpButtonsEnabled">
+      <v-btn
+        id="jump-button-500"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(500)"
+      >500km</v-btn>
+      <v-btn
+        id="jump-button-50"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(50)"
+      >50km</v-btn>
+      <v-btn
+        id="jump-button-10"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(10)"
+      >10km</v-btn>
+      <v-btn
+        id="jump-button-1"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(1)"
+      >1km</v-btn>
+    </v-container>
     <div id="street-view-anchor" />
   </div>
 </template>
@@ -20,6 +54,14 @@
   z-index: 2;
   right: 10px;
   bottom: 210px;
+}
+
+.jump-button {
+  position: absolute;
+  z-index: 2;
+  right: 10px;
+  width: 50px;
+  height: 50px;
 }
 
 #street-view-container {
@@ -35,38 +77,80 @@
   height: 50px;
 }
 
+#jump-button-1 {
+  bottom: 310px;
+}
+
+#jump-button-10 {
+  bottom: 410px;
+}
+
+#jump-button-50 {
+  bottom: 510px;
+}
+
+#jump-button-500 {
+  bottom: 610px;
+}
+
 #street-view-anchor {
   flex-grow: 1;
 }
 </style>
 
 <script>
+import maps from '@/maps_util.js';
+
 /*global google*/
 
 const DEFAULT_POV = { heading: -110, pitch: 0 };
 
 export default {
   props: {
-    mapPosition: {
+    initialMapPosition: {
       type: Object,
+      required: true,
+    },
+    jumpButtonsEnabled: {
+      type: Boolean,
       required: true,
     },
   },
   data: function() {
-    return {};
+    return {
+      mapPosition: { lat: 37.75598, lng: -122.41231 },
+    };
   },
   name: 'Streets',
   methods: {
     goBackToStart: function() {
-      this.panorama.setPosition(this.mapPosition);
+      this.panorama.setPosition(this.initialMapPosition);
       this.panorama.setPov(DEFAULT_POV);
+    },
+    jump: async function(distance_km) {
+      const position = this.panorama.getPosition();
+      let bearing_deg = this.panorama.getPov().heading;
+      if (bearing_deg > 180) {
+        bearing_deg = bearing_deg - 360;
+      }
+      const new_position = await maps.jumpByDistanceAndBearing(
+        {lat: position.lat(), lng: position.lng()}, distance_km, bearing_deg);
+      if (new_position != null) {
+        console.log(
+          "Closest panorama is at lat: ", new_position.destination.lat,
+          "; lng: ", new_position.destination.lng,
+          "distance: ", new_position.distance_km);
+        this.panorama.setPosition(new_position.destination);
+      } else {
+        console.log("Can't find panorama in this direction.");
+      }
     },
   },
   mounted: function() {
     this.panorama = new google.maps.StreetViewPanorama(
       document.getElementById('street-view-anchor'),
       {
-        position: this.mapPosition,
+        position: this.initialMapPosition,
         pov: DEFAULT_POV,
         zoom: 1,
         addressControl: false,
@@ -78,16 +162,23 @@ export default {
         panControl: true,
       },
     );
+    this.panorama.addListener("position_changed", () => {
+      const pos = this.panorama.getPosition();
+      this.mapPosition = pos.toJSON();
+      console.log("Position changed in streetview:", this.mapPosition);
+    });
   },
   watch: {
+    initialMapPosition: function(newValue, oldValue) {
+      console.log(
+        "initialMapPosition changed, forcing streetview position to: ",
+        newValue);
+      this.panorama.setPosition(newValue);
+    },
     mapPosition: function(newValue, oldValue) {
-      // this is stupid, why do I even bother...
-      if (JSON.stringify(oldValue) != JSON.stringify(newValue)) {
-        this.$nextTick(function() {
-          this.panorama.setPosition(this.mapPosition);
-          this.panorama.setPov(DEFAULT_POV);
-        });
-      }
+      console.log(
+        "mapPosition changed to", newValue, "emitting position_changed");
+      this.$emit('position_changed', newValue);
     },
   },
 };

--- a/src/views/Game.vue
+++ b/src/views/Game.vue
@@ -54,7 +54,10 @@
       v-bind:playerGuessStatus="players"
       v-bind:isChief="isChief()"
     />
-    <Streets v-bind:mapPosition="mapPosition" />
+    <Streets
+      v-bind:initialMapPosition="mapPosition"
+      v-bind:jumpButtonsEnabled=false
+    />
     <div id="map-overlay">
       <MarkerMap
         @on-guess="guess($event)"


### PR DESCRIPTION
This PR is based on #38, and is meant to be merged after that PR is merged.
It implements a key feature for #37 : the ability to jump forward for some distance in the direction the player is facing.
This is disabled in the classic game mode, so there should be no change.

Manual testing: I tried the classic game mode, and saw the buttons weren't there.