### PR TITLE
Rendezvous game state generation and lobby setting

### DIFF
--- a/src/game_gen/game_generator.js
+++ b/src/game_gen/game_generator.js
@@ -36,12 +36,17 @@ export class GameGenerator {
     this.getShapeOptsFn = getShapeOptsFn;
   }
 
-  startGeneration(shapeNames, kmlUrl) {
-    console.log('Starting game generation...', kmlUrl);
+  startGeneration(gameMode, shapeNames, kmlUrl, players) {
+    console.log(
+      'Starting game generation. gameMode: ', gameMode,
+      'shapeNames: ', shapeNames, 'kmlUrl: ', kmlUrl,
+      'players: ', players, 'generator: ', this);
     if (kmlUrl != null && kmlUrl != '') {
-      this.work = this.fetchKmlAndGenerateGame(kmlUrl);
+      this.work = this.fetchKmlAndGenerateGame(
+        gameMode, kmlUrl, players);
     } else {
-      this.work = this.fetchShapesAndGenerateGame(shapeNames);
+      this.work = this.fetchShapesAndGenerateGame(
+        gameMode, shapeNames, players);
     }
   }
 
@@ -58,14 +63,15 @@ export class GameGenerator {
     await this.work;
   }
 
-  async fetchShapesAndGenerateGame(shapeNames) {
+  async fetchShapesAndGenerateGame(gameMode, shapeNames, players) {
     if (this.cancelled) throw new CancelledError();
 
     await this.fetchShapes(shapeNames);
     console.log('Generating from shapes: ', this.shapes);
 
     if (this.cancelled) throw new CancelledError();
-    await this.generateRounds(this.generateValidPosition.bind(this));
+    await this.generateGameState(
+      gameMode, players, this.generateValidPosition.bind(this));
   }
 
   shuffleArray(array) {
@@ -97,15 +103,15 @@ export class GameGenerator {
     return null;
   }
 
-  async fetchKmlAndGenerateGame(kmlUrl) {
+  async fetchKmlAndGenerateGame(gameMode, kmlUrl, players) {
     let points = await this.fetchKml(kmlUrl);
 
     this.kmlPoints = this.shuffleArray(points);
 
     if (this.cancelled) throw new CancelledError();
-    await this.generateRounds(
-      this.generateValidPositionFromKmlPoints.bind(this),
-    );
+    await this.generateGameState(
+      gameMode, players,
+       this.generateValidPositionFromKmlPoints.bind(this));
   }
 
   async fetchKml(kmlUrl) {
@@ -169,7 +175,67 @@ export class GameGenerator {
     });
   }
 
-  async generateRounds(posGenFn) {
+  async generateGameState(gameMode, players, posGenFn) {
+    if (gameMode == "classic") {
+      await this.generateClassicGameState(posGenFn);
+    } else if (gameMode == "rendezvous") {
+      await this.generateRendezvousGameState(players, posGenFn);
+    } else {
+      console.log("Unrecognized gameMode: ", gameMode);
+    }
+  }
+
+  // The player state for Rendezvous is encapsulated in the
+  // rendezvous_data field in the database. The structure is as follows:
+  // * rendezvous_data:
+  //   * player_data: a dictionary mapping player_ids to their position
+  //                  and history.
+  //     * [player_id]: the key used to identify players in geoguessr.
+  //       * map_position: object with {lat, lng} fields, storing the
+  //                       initial/current player position.
+  //       * position_history: array of objects with {lat, lng} fields,
+  //                           storing the points the player visited, in order.
+  //   * finished: a boolean indicating if the game is finished and a result
+  //               screen should be shown to all players.
+  async generateRendezvousGameState(players, posGenFn) {
+    console.log("Generating Rendezvous game state for:", players);
+    if (this.cancelled) throw new CancelledError();
+
+    const rendezvous_player_data = {};
+    let i = 0;
+    for (const [player, player_name] of Object.entries(players)) {
+      if (this.cancelled) throw new CancelledError();
+
+      const position = await posGenFn();
+      if (position === null) {
+        throw new Error(
+          'Could not find enough valid points within the selected ' +
+            'locations. Try different location settings.',
+        );
+      }
+      rendezvous_player_data[player] = {
+        map_position: position,
+        position_history: [position],
+      };
+    }
+    const rendezvous_data = {
+      player_data: rendezvous_player_data,
+      finished: false,
+    };
+
+    if (this.cancelled) throw new CancelledError();
+
+    try {
+      const roomRef = firebase.database().ref(this.roomPath);
+      await roomRef.child('rendezvous_data').set(rendezvous_data);
+    } catch (error) {
+      console.error('Failed to write player locations to db with error: ', error);
+      throw new Error('Cannot connect to Firebase.');
+    }
+  }
+
+  async generateClassicGameState(posGenFn) {
+    console.log("Generating Classic game state");
     if (this.cancelled) throw new CancelledError();
 
     const rounds = {};

--- a/src/game_gen/game_generator.js
+++ b/src/game_gen/game_generator.js
@@ -38,15 +38,25 @@ export class GameGenerator {
 
   startGeneration(gameMode, shapeNames, kmlUrl, players) {
     console.log(
-      'Starting game generation. gameMode: ', gameMode,
-      'shapeNames: ', shapeNames, 'kmlUrl: ', kmlUrl,
-      'players: ', players, 'generator: ', this);
+      'Starting game generation. gameMode: ',
+      gameMode,
+      'shapeNames: ',
+      shapeNames,
+      'kmlUrl: ',
+      kmlUrl,
+      'players: ',
+      players,
+      'generator: ',
+      this,
+    );
     if (kmlUrl != null && kmlUrl != '') {
-      this.work = this.fetchKmlAndGenerateGame(
-        gameMode, kmlUrl, players);
+      this.work = this.fetchKmlAndGenerateGame(gameMode, kmlUrl, players);
     } else {
       this.work = this.fetchShapesAndGenerateGame(
-        gameMode, shapeNames, players);
+        gameMode,
+        shapeNames,
+        players,
+      );
     }
   }
 
@@ -71,7 +81,10 @@ export class GameGenerator {
 
     if (this.cancelled) throw new CancelledError();
     await this.generateGameState(
-      gameMode, players, this.generateValidPosition.bind(this));
+      gameMode,
+      players,
+      this.generateValidPosition.bind(this),
+    );
   }
 
   shuffleArray(array) {
@@ -110,8 +123,10 @@ export class GameGenerator {
 
     if (this.cancelled) throw new CancelledError();
     await this.generateGameState(
-      gameMode, players,
-       this.generateValidPositionFromKmlPoints.bind(this));
+      gameMode,
+      players,
+      this.generateValidPositionFromKmlPoints.bind(this),
+    );
   }
 
   async fetchKml(kmlUrl) {
@@ -176,12 +191,12 @@ export class GameGenerator {
   }
 
   async generateGameState(gameMode, players, posGenFn) {
-    if (gameMode == "classic") {
+    if (gameMode == 'classic') {
       await this.generateClassicGameState(posGenFn);
-    } else if (gameMode == "rendezvous") {
+    } else if (gameMode == 'rendezvous') {
       await this.generateRendezvousGameState(players, posGenFn);
     } else {
-      console.log("Unrecognized gameMode: ", gameMode);
+      console.error('Unrecognized gameMode: ', gameMode);
     }
   }
 
@@ -198,12 +213,11 @@ export class GameGenerator {
   //   * finished: a boolean indicating if the game is finished and a result
   //               screen should be shown to all players.
   async generateRendezvousGameState(players, posGenFn) {
-    console.log("Generating Rendezvous game state for:", players);
+    console.log('Generating Rendezvous game state for:', players);
     if (this.cancelled) throw new CancelledError();
 
     const rendezvous_player_data = {};
-    let i = 0;
-    for (const [player, player_name] of Object.entries(players)) {
+    for (const player of Object.keys(players)) {
       if (this.cancelled) throw new CancelledError();
 
       const position = await posGenFn();
@@ -229,13 +243,16 @@ export class GameGenerator {
       const roomRef = firebase.database().ref(this.roomPath);
       await roomRef.child('rendezvous_data').set(rendezvous_data);
     } catch (error) {
-      console.error('Failed to write player locations to db with error: ', error);
+      console.error(
+        'Failed to write player locations to db with error: ',
+        error,
+      );
       throw new Error('Cannot connect to Firebase.');
     }
   }
 
   async generateClassicGameState(posGenFn) {
-    console.log("Generating Classic game state");
+    console.log('Generating Classic game state');
     if (this.cancelled) throw new CancelledError();
 
     const rounds = {};

--- a/src/store/modules/game_gen.store.js
+++ b/src/store/modules/game_gen.store.js
@@ -16,8 +16,7 @@ const mutations = {
     state.gameGenerator = gameGenerator;
   },
   startGameGenerator(state, { gameMode, shapeNames, kmlUrl, players }) {
-    state.gameGenerator.startGeneration(
-      gameMode, shapeNames, kmlUrl, players);
+    state.gameGenerator.startGeneration(gameMode, shapeNames, kmlUrl, players);
   },
   cancelCurrentGenerator(state) {
     state.gameGenerator.cancel();

--- a/src/store/modules/game_gen.store.js
+++ b/src/store/modules/game_gen.store.js
@@ -15,8 +15,9 @@ const mutations = {
   setNewGameGenerator(state, { gameGenerator }) {
     state.gameGenerator = gameGenerator;
   },
-  startGameGenerator(state, { shapeNames, kmlUrl }) {
-    state.gameGenerator.startGeneration(shapeNames, kmlUrl);
+  startGameGenerator(state, { gameMode, shapeNames, kmlUrl, players }) {
+    state.gameGenerator.startGeneration(
+      gameMode, shapeNames, kmlUrl, players);
   },
   cancelCurrentGenerator(state) {
     state.gameGenerator.cancel();
@@ -41,6 +42,12 @@ const mutations = {
   },
   setKmlUrl(state, kmlUrl) {
     state.kmlUrl = kmlUrl;
+  },
+  setGameMode(state, gameMode) {
+    state.gameMode = gameMode;
+  },
+  setPlayers(state, players) {
+    state.players = players;
   },
 };
 
@@ -87,8 +94,10 @@ const actions = {
       }
     }
     commit('startGameGenerator', {
+      gameMode: state.gameMode,
       shapeNames: state.currentlySelectedShapes,
       kmlUrl: state.kmlUrl,
+      players: state.players,
     });
   },
   async waitToFinishGeneration({ state, commit }) {

--- a/src/views/Lobby.vue
+++ b/src/views/Lobby.vue
@@ -269,6 +269,7 @@ export default {
       'showPersistentDialog',
       'hidePersistentDialog',
     ]),
+    ...mapMutations('gameGen', ['setPlayers']),
     ...mapMutations('dialog', ['showDialog']),
   },
   computed: {
@@ -340,6 +341,14 @@ export default {
         console.error('We lost "chief" status! This should never happen!');
       }
       this.triggerGameRegeneration({ roomPath: roomObjectPath(this.roomId) });
+    },
+    connected_players: function(newVal) {
+      this.setPlayers(this.connected_players);
+      if (!this.isChief) {
+        this.triggerGameRegeneration({
+          roomPath: roomObjectPath(this.roomId),
+        });
+      }
     },
   },
   unmounted: function() {

--- a/src/views/Lobby.vue
+++ b/src/views/Lobby.vue
@@ -343,7 +343,7 @@ export default {
       this.triggerGameRegeneration({ roomPath: roomObjectPath(this.roomId) });
     },
     connected_players: function(newVal) {
-      this.setPlayers(this.connected_players);
+      this.setPlayers(newVal);
       if (!this.isChief) {
         this.triggerGameRegeneration({
           roomPath: roomObjectPath(this.roomId),


### PR DESCRIPTION
This change for #37 creates a lobby option for picking between the available game modes (hidden for now, until Rendezvous is ready) and initializes the rendezvous game state. The game mode and list of players are now both stored in the game generation Store. The game mode is set in the LobbyOptions, the list of players in the Lobby.
A new game generation is triggered when either of these changes.
Screenshots:
![Lobby when rendezvous is picked](https://user-images.githubusercontent.com/802495/110249039-3bbb5a00-7f74-11eb-8dc6-520a5baf3ba5.jpg)
![Lobby when classic is picked](https://user-images.githubusercontent.com/802495/110249044-47a71c00-7f74-11eb-9a27-33085f6c1993.jpg)

