### PR TITLE
Experiment store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,13 +1189,13 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.2.tgz",
-      "integrity": "sha512-4Ceov+rPfOEPIdbjlpTim/wbcUUneIesHag4UOzvmFsRRXqbxLwQpyZQWEbTSriUeU8uTKj9yOW32hsskV9Klg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.4.tgz",
+      "integrity": "sha512-Lhnk5pXeDKoPf1b2cggWQaqCtNq+jn6IkhHMIo+7VztVt3i8ovnGuhAn/0hLC+XxvVWJ9q6CXIoGStkwvecDoA==",
       "requires": {
         "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
@@ -1207,12 +1207,12 @@
       "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
     },
     "@firebase/app": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.14.tgz",
-      "integrity": "sha512-ZQKuiJ+fzr4tULgWoXbW+AZVTGsejOkSrlQ+zx78WiGKIubpFJLklnP3S0oYr/1nHzr4vaKuM4G8IL1Wv/+MpQ==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.15.tgz",
+      "integrity": "sha512-VfULP09cci4xk+iAU6CB2CUNU/vbpAOoUleDdspXFphV9Yw36anb8RjaHGcN1DRR7LNb7vznNJXHk8FJhC8VWQ==",
       "requires": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "dom-storage": "2.1.0",
@@ -1226,11 +1226,11 @@
       "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "@firebase/auth": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.3.tgz",
-      "integrity": "sha512-0U+SJrh9K8vDv+lvWPYU9cAQBRPt8fpm3cK7yRZAwnN4jbcqfg+KBaddrDn28aIQYX+n4TrLiZ9TMJXPJfUYhQ==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.4.tgz",
+      "integrity": "sha512-zgHPK6/uL6+nAyG9zqammHTF1MQpAN7z/jVRLYkDZS4l81H08b2SzApLbRfW/fmy665xqb5MK7sVH0V1wsiCNw==",
       "requires": {
-        "@firebase/auth-types": "0.10.1"
+        "@firebase/auth-types": "0.10.2"
       }
     },
     "@firebase/auth-interop-types": {
@@ -1239,41 +1239,31 @@
       "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw=="
     },
     "@firebase/auth-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
+      "integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg=="
     },
     "@firebase/component": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.2.0.tgz",
+      "integrity": "sha512-QJJxMEzLRMWjujPBrrS32BScg1wmdY/dZWR8nAEzyC8WKQsNevYR9ZKLbBYxaN0umH9yf5C40kwmy+gI8jStPw==",
       "requires": {
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
       }
     },
     "@firebase/database": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.3.tgz",
-      "integrity": "sha512-/ZxABwwknVFypPivQGRauF0WE9ZNr+WCucwCqAhxzQPgfUOaAKL5PZs9Oa/Yz42gMMfmjF+z6hPvSjW2ePlEcA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.4.tgz",
+      "integrity": "sha512-Fw2bA4OyxAMqLy8xtoZKlUAuDWjjH/z4AInRTAzHxgegXDbu0UK+VM0pmY44RuM2cmnVY4aW6xLXAdDKTY1aJQ==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/database-types": "0.7.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "faye-websocket": "0.11.3",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.11.3",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        }
       }
     },
     "@firebase/database-types": {
@@ -1285,11 +1275,11 @@
       }
     },
     "@firebase/firestore": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.6.tgz",
-      "integrity": "sha512-T7hNYP6lH3i6rqAzXvIqh30GmUvAl+6C4yUvrdHtz+RO3MeReK1TCE4mmAWBZApLCibVIZiMJ581qRB8KnON7A==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.7.tgz",
+      "integrity": "sha512-sh+aX6udS8a+rwmlJO4zJwvoMC1D2x1CiPvj0nFYWhILRKWvztk/bOA3lT2FWcHY4kr/7x+CnqfwtiOSaufdNQ==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/firestore-types": "2.1.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
@@ -1298,13 +1288,6 @@
         "@grpc/proto-loader": "^0.5.0",
         "node-fetch": "2.6.1",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
       }
     },
     "@firebase/firestore-types": {
@@ -1313,22 +1296,15 @@
       "integrity": "sha512-jietErBWihMvJkqqEquQy5GgoEwzHnMXXC/TsVoe9FPysXm1/AeJS12taS7ZYvenAtyvL/AEJyKrRKRh4adcJQ=="
     },
     "@firebase/functions": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
-      "integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.2.tgz",
+      "integrity": "sha512-f+NxRd0k5RBPZUPj8lykeNMku8TpJTgZaRd3T6cXb8HbmSg/VY7uxQSGOXe11X2gSv/TvcwTQttViFzRMDs7CQ==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
       }
     },
     "@firebase/functions-types": {
@@ -1337,11 +1313,11 @@
       "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
     },
     "@firebase/installations": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
-      "integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.20.tgz",
+      "integrity": "sha512-ddUPZQKHWJzqg3g11hxHIPhp3oMEmsPo0GSxtp9Xd2VLRU64MFNAAt5PiBbq1K92ukZVoNh6Ki6J6+hJEQcGQw==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/installations-types": "0.3.4",
         "@firebase/util": "0.3.4",
         "idb": "3.0.2",
@@ -1359,12 +1335,12 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "@firebase/messaging": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
-      "integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.4.tgz",
+      "integrity": "sha512-xIZ1vHnOcHAaj+H/gS8tu3QolR9up+fyTfgVLEFbZRsbAiLuIvuaoJwTHLAUTs/nJF6GtEGscRD4Jx/aFmEJRw==",
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/messaging-types": "0.5.0",
         "@firebase/util": "0.3.4",
         "idb": "3.0.2",
@@ -1377,12 +1353,12 @@
       "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
     },
     "@firebase/performance": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.5.tgz",
-      "integrity": "sha512-oenEOaV/UzvV8XPi8afYQ71RzyrHoBesqOyXqb1TOg7dpU+i+UJ5PS8K64DytKUHTxQl+UJFcuxNpsoy9BpWzw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.6.tgz",
+      "integrity": "sha512-fy9YPYnvePFxme7euyi8B658gF8JUQhAB1qv6hVw+HqjVZQIANhwM9AUBi9+5jikD7gD1CnU7EjREvoy8MJiAw==",
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
         "@firebase/util": "0.3.4",
@@ -1405,12 +1381,12 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
-      "integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.31.tgz",
+      "integrity": "sha512-QWjDsrLSqQnq/YTb3TSOJtIv7z2GXB7mTiwXE43NxYmsOX2z8KBlBBEHf9TcWk+90MKUTFfurDgYJN4rlIOxPg==",
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
         "@firebase/util": "0.3.4",
@@ -1423,11 +1399,11 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "@firebase/storage": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
-      "integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.3.tgz",
+      "integrity": "sha512-53IIt6Z3BltPBPmvxF/RGlvW8nBl4wI9GMR52CjRAIj438tPNxbpIvkLB956VVB9gfZhDcPIKxg7hNtC7hXrkA==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/storage-types": "0.3.13",
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
@@ -1537,9 +1513,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.7.tgz",
-      "integrity": "sha512-hBkR/vZTodu/dA/kcKpiQtPQdjMbpfKv7RKfEByT5/7qOQNpIh2O6Sr1aldLMzstFqmGrufmR7XTc56VCMH7LA==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.10.tgz",
+      "integrity": "sha512-wj6GkNiorWYaPiIZ767xImmw7avMMVUweTvPFg4mJWOxz2180DKwfuxhJJZ7rpc1+7D3mX/v8vJdxTuIo71Ieg==",
       "requires": {
         "@types/node": ">=12.12.47",
         "google-auth-library": "^6.1.1",
@@ -2091,6 +2067,22 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@turf/bbox": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.3.0.tgz",
+      "integrity": "sha512-N4ue5Xopu1qieSHP2MA/CJGWHPKaTrVXQJjzHRNcY1vtsO126xbSaJhWUrFc5x5vVkXp0dcucGryO0r5m4o/KA==",
+      "requires": {
+        "@turf/helpers": "^6.3.0",
+        "@turf/meta": "^6.3.0"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+        }
+      }
+    },
     "@turf/boolean-point-in-polygon": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz",
@@ -2098,6 +2090,46 @@
       "requires": {
         "@turf/helpers": "6.x",
         "@turf/invariant": "6.x"
+      }
+    },
+    "@turf/center": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.3.0.tgz",
+      "integrity": "sha512-41g/ZYwoBs2PK7tpAHhf4D6llHdRvY827HLXCld5D0IOnzsWPqDk7WnV8P5uq4g/gyH1/WfKQYn5SgfSj4sSfw==",
+      "requires": {
+        "@turf/bbox": "^6.3.0",
+        "@turf/helpers": "^6.3.0"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+        }
+      }
+    },
+    "@turf/destination": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.3.0.tgz",
+      "integrity": "sha512-aLt3U/XkJWyZW08Ln1qZwBNAGh27yhmYLu892+dBj3gKP6UUiR6ZopXxrBwjBVe00A6k2ktftKDn79qe0hptuw==",
+      "requires": {
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+        },
+        "@turf/invariant": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
+          "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
+          "requires": {
+            "@turf/helpers": "^6.3.0"
+          }
+        }
       }
     },
     "@turf/helpers": {
@@ -2113,12 +2145,36 @@
         "@turf/helpers": "6.x"
       }
     },
+    "@turf/meta": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
+      "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
+      "requires": {
+        "@turf/helpers": "^6.3.0"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+        }
+      }
+    },
     "@turf/random": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@turf/random/-/random-6.0.2.tgz",
       "integrity": "sha512-kAJhZ2QZ4kM2ArI0lrFLtq1LCH4ZSjleUlj1izi/405XenjddjrbgtewpZte8IxCSeV4yK46lsDRS1911cF5lg==",
       "requires": {
         "@turf/helpers": "6.x"
+      }
+    },
+    "@types/archiver": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
+      "integrity": "sha512-baFOhanb/hxmcOd1Uey2TfFg43kTSmM6py1Eo7Rjbv/ivcl7PXLhY0QgXGf50Hx/eskGCFqPfhs/7IZLb15C5g==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*"
       }
     },
     "@types/babel__core": {
@@ -2175,6 +2231,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/filesize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/filesize/-/filesize-5.0.0.tgz",
+      "integrity": "sha512-zgn1Kmm6VfqruG9STpwpZiSnpzHjF9hlvHVw+5hhM20xRCOIgjxnXJxOoLuZ/aWS6v/M5d6fvXFbbVQfBe4cMg==",
+      "dev": true,
+      "requires": {
+        "filesize": "*"
       }
     },
     "@types/glob": {
@@ -3330,28 +3395,25 @@
       "dev": true
     },
     "archiver": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
+      "integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
-        "async": "^2.6.3",
+        "async": "^3.2.0",
         "buffer-crc32": "^0.2.1",
-        "glob": "^7.1.4",
-        "readable-stream": "^3.4.0",
-        "tar-stream": "^2.1.0",
-        "zip-stream": "^2.1.2"
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.1.4",
+        "zip-stream": "^4.0.4"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "dev": true
         },
         "readable-stream": {
           "version": "3.6.0",
@@ -4700,6 +4762,16 @@
         "os-homedir": "^1.0.1"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -5483,15 +5555,28 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+      "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
       "dev": true,
       "requires": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^3.0.1",
+        "crc32-stream": "^4.0.1",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^2.3.6"
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "compressible": {
@@ -5763,9 +5848,9 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+      "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.3",
@@ -5778,7 +5863,7 @@
         "normalize-path": "^3.0.0",
         "p-limit": "^2.2.1",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "webpack-log": "^2.0.0"
       },
       "dependencies": {
@@ -5841,10 +5926,13 @@
           }
         },
         "serialize-javascript": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-          "dev": true
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
         },
         "slash": {
           "version": "1.0.0",
@@ -5906,34 +5994,23 @@
         }
       }
     },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.1.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "crc32-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
+      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
       "dev": true,
       "requires": {
-        "crc": "^3.4.4",
+        "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "dependencies": {
@@ -7693,9 +7770,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "events": {
@@ -7848,6 +7925,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
       "dev": true
     },
     "expand-brackets": {
@@ -8260,10 +8343,9 @@
       }
     },
     "faye-websocket": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true,
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
@@ -8433,36 +8515,38 @@
       }
     },
     "firebase": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.7.tgz",
-      "integrity": "sha512-HSfaOQjSA//VKxPmPfjKmv8HMH5DwdckaKXKpBJCHSkBkqqFehP5dG9I7+06X1GTycXgg6U6i1zqqBSt6zWTxw==",
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.10.tgz",
+      "integrity": "sha512-fGDrVWEDbFf4uaRhOMmbLf4CfW3D98GsMsbnvfd/5lPw5wTpUUcVjHyhXxcB+qfu66WeNW5kEKlEKLJmQXTkYw==",
       "requires": {
-        "@firebase/analytics": "0.6.2",
-        "@firebase/app": "0.6.14",
+        "@firebase/analytics": "0.6.4",
+        "@firebase/app": "0.6.15",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.16.3",
-        "@firebase/database": "0.9.3",
-        "@firebase/firestore": "2.1.6",
-        "@firebase/functions": "0.6.1",
-        "@firebase/installations": "0.4.19",
-        "@firebase/messaging": "0.7.3",
-        "@firebase/performance": "0.4.5",
+        "@firebase/auth": "0.16.4",
+        "@firebase/database": "0.9.4",
+        "@firebase/firestore": "2.1.7",
+        "@firebase/functions": "0.6.2",
+        "@firebase/installations": "0.4.20",
+        "@firebase/messaging": "0.7.4",
+        "@firebase/performance": "0.4.6",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.30",
-        "@firebase/storage": "0.4.2",
+        "@firebase/remote-config": "0.1.31",
+        "@firebase/storage": "0.4.3",
         "@firebase/util": "0.3.4"
       }
     },
     "firebase-tools": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-9.3.0.tgz",
-      "integrity": "sha512-tLg1GKpf8Jxlgqq3JttWTOHsOKIyNpro0Ic5sOabmxd1XSeXdK0XW3r3INASoSpy1SYPQn5EEyR1Vs/a0gCu2w==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-9.4.0.tgz",
+      "integrity": "sha512-qqiNUiMb60GNIz/d8lv4eCSzBU/0AjcdnwWfGsOlGgeWRks9SeuWXvXt6JF7bn/7t15+z41Q7S4avsIRhAHD1Q==",
       "dev": true,
       "requires": {
         "@google-cloud/pubsub": "^2.7.0",
+        "@types/archiver": "^5.1.0",
+        "@types/filesize": "^5.0.0",
         "JSONStream": "^1.2.1",
         "abort-controller": "^3.0.0",
-        "archiver": "^3.0.0",
+        "archiver": "^5.0.0",
         "body-parser": "^1.19.0",
         "chokidar": "^3.0.2",
         "cjson": "^0.3.1",
@@ -8477,7 +8561,7 @@
         "exegesis-express": "^2.0.0",
         "exit-code": "^1.0.2",
         "express": "^4.16.4",
-        "filesize": "^3.1.3",
+        "filesize": "^6.1.0",
         "fs-extra": "^0.23.1",
         "glob": "^7.1.2",
         "google-auth-library": "^6.1.3",
@@ -8564,6 +8648,12 @@
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
+        },
+        "filesize": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
+          "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
+          "dev": true
         },
         "fs-extra": {
           "version": "0.23.1",
@@ -9074,6 +9164,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -9710,9 +9811,9 @@
       }
     },
     "html-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
       "dev": true
     },
     "html-escaper": {
@@ -9872,6 +9973,12 @@
           "dev": true
         }
       }
+    },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+      "dev": true
     },
     "http-proxy": {
       "version": "1.18.1",
@@ -10325,10 +10432,13 @@
       }
     },
     "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -12540,9 +12650,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
     },
     "long": {
@@ -13220,14 +13330,14 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-gyp": {
@@ -13585,13 +13695,13 @@
       "dev": true
     },
     "object-is": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
+      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "object-keys": {
@@ -14886,6 +14996,12 @@
         "react-is": "^16.8.4"
       }
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -15116,9 +15232,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
     "ramda": {
@@ -15244,6 +15360,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdir-glob": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
+      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "readdirp": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
@@ -15321,13 +15446,13 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "regexpp": {
@@ -15913,12 +16038,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {
@@ -16347,46 +16472,50 @@
       }
     },
     "sockjs": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
-      "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
       "dev": true,
       "requires": {
-        "faye-websocket": "^0.10.0",
+        "faye-websocket": "^0.11.3",
         "uuid": "^3.4.0",
-        "websocket-driver": "0.6.5"
+        "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "websocket-driver": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+          "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+          "dev": true,
+          "requires": {
+            "http-parser-js": ">=0.5.1",
+            "safe-buffer": ">=5.1.0",
+            "websocket-extensions": ">=0.1.1"
+          }
+        }
       }
     },
     "sockjs-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
-      "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
+      "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
       "dev": true,
       "requires": {
-        "debug": "^3.2.5",
+        "debug": "^3.2.6",
         "eventsource": "^1.0.7",
-        "faye-websocket": "~0.11.1",
-        "inherits": "^2.0.3",
-        "json3": "^3.3.2",
-        "url-parse": "^1.4.3"
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.4.7"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "faye-websocket": {
-          "version": "0.11.3",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
-          "dev": true,
-          "requires": {
-            "websocket-driver": ">=0.5.1"
           }
         }
       }
@@ -18059,9 +18188,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -18646,9 +18775,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-      "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz",
+      "integrity": "sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==",
       "dev": true,
       "requires": {
         "memory-fs": "^0.4.1",
@@ -18659,9 +18788,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
-      "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
+      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -18684,11 +18813,11 @@
         "p-retry": "^3.0.1",
         "portfinder": "^1.0.26",
         "schema-utils": "^1.0.0",
-        "selfsigned": "^1.10.7",
+        "selfsigned": "^1.10.8",
         "semver": "^6.3.0",
         "serve-index": "^1.9.1",
-        "sockjs": "0.3.20",
-        "sockjs-client": "1.4.0",
+        "sockjs": "^0.3.21",
+        "sockjs-client": "^1.5.0",
         "spdy": "^4.0.2",
         "strip-ansi": "^3.0.1",
         "supports-color": "^6.1.0",
@@ -19347,14 +19476,14 @@
       }
     },
     "zip-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-      "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+      "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^2.1.1",
-        "readable-stream": "^3.4.0"
+        "compress-commons": "^4.0.2",
+        "readable-stream": "^3.6.0"
       },
       "dependencies": {
         "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@turf/boolean-point-in-polygon": "^6.0.1",
     "@turf/random": "^6.0.2",
+    "@turf/center": "^6.0.2",
+    "@turf/destination": "^6.0.2",
     "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "firebase": "^8.2.7",

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,15 +1,32 @@
 <template>
-  <v-app-bar app color="primary" class="white--text" dense>
+  <v-app-bar app v-bind:color="getColor()" class="white--text" dense>
     <v-spacer></v-spacer>
     <v-toolbar-title style="cursor: pointer" @click="$router.push('/')">
-      GeoGuess
+      GeoGuess <span v-if="rendezvous_enabled">(Rendezvous enabled!!!!)</span>
     </v-toolbar-title>
     <v-spacer></v-spacer>
   </v-app-bar>
 </template>
 
 <script>
+import { mapGetters, mapMutations } from 'vuex';
+
 export default {
   name: 'Header',
+  computed: {
+    rendezvous_enabled: function() {
+      return this.getRendezvousEnabled();
+    }
+  },
+  methods: {
+    getColor() {
+      if (this.rendezvous_enabled) {
+        return "red";
+      }
+      return "primary";
+    },
+    ...mapGetters('experiment', ['getRendezvousEnabled']),
+    ...mapMutations('experiment', ['setRendezvousEnabled']),
+  }
 };
 </script>

--- a/src/components/LobbyOptions.vue
+++ b/src/components/LobbyOptions.vue
@@ -2,7 +2,7 @@
   <v-card outlined>
     <v-card-title>Game options</v-card-title>
     <v-container>
-      <v-container v-if="showGameModePicker">
+      <v-container v-if="getRendezvousEnabled()">
         <v-row>
           <v-col>
             <v-select
@@ -66,7 +66,7 @@
 import firebase from 'firebase/app';
 import _ from 'lodash';
 import 'firebase/database';
-import { mapActions, mapMutations } from 'vuex';
+import { mapGetters, mapActions, mapMutations } from 'vuex';
 import { roomObjectPath } from '@/firebase_utils.js';
 import { fetchShapesIndex } from '@/game_gen/shapes_util.js';
 
@@ -95,7 +95,6 @@ export default {
       availableShapeNames: [],
       timeLimitSyncing: false,
       shapesInputSyncing: false,
-      showGameModePicker: false,
     };
   },
   computed: {
@@ -246,6 +245,7 @@ export default {
         this.playersDbRef.off();
       }
     },
+    ...mapGetters('experiment', ['getRendezvousEnabled']),
     ...mapActions('gameGen', ['triggerGameRegeneration']),
     ...mapMutations('gameGen', [
       'setAvailableShapes', 'setSelectedShapes', 'setKmlUrl',

--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -10,6 +10,40 @@
     >
       <v-icon large>mdi-anchor</v-icon>
     </v-btn>
+    <v-container v-if="jumpButtonsEnabled">
+      <v-btn
+        id="jump-button-500"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(500)"
+      >500km</v-btn>
+      <v-btn
+        id="jump-button-50"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(50)"
+      >50km</v-btn>
+      <v-btn
+        id="jump-button-10"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(10)"
+      >10km</v-btn>
+      <v-btn
+        id="jump-button-1"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="jump(1)"
+      >1km</v-btn>
+    </v-container>
     <div id="street-view-anchor" />
   </div>
 </template>
@@ -20,6 +54,14 @@
   z-index: 2;
   right: 10px;
   bottom: 210px;
+}
+
+.jump-button {
+  position: absolute;
+  z-index: 2;
+  right: 10px;
+  width: 50px;
+  height: 50px;
 }
 
 #street-view-container {
@@ -35,38 +77,80 @@
   height: 50px;
 }
 
+#jump-button-1 {
+  bottom: 310px;
+}
+
+#jump-button-10 {
+  bottom: 410px;
+}
+
+#jump-button-50 {
+  bottom: 510px;
+}
+
+#jump-button-500 {
+  bottom: 610px;
+}
+
 #street-view-anchor {
   flex-grow: 1;
 }
 </style>
 
 <script>
+import maps from '@/maps_util.js';
+
 /*global google*/
 
 const DEFAULT_POV = { heading: -110, pitch: 0 };
 
 export default {
   props: {
-    mapPosition: {
+    initialMapPosition: {
       type: Object,
+      required: true,
+    },
+    jumpButtonsEnabled: {
+      type: Boolean,
       required: true,
     },
   },
   data: function() {
-    return {};
+    return {
+      mapPosition: { lat: 37.75598, lng: -122.41231 },
+    };
   },
   name: 'Streets',
   methods: {
     goBackToStart: function() {
-      this.panorama.setPosition(this.mapPosition);
+      this.panorama.setPosition(this.initialMapPosition);
       this.panorama.setPov(DEFAULT_POV);
+    },
+    jump: async function(distance_km) {
+      const position = this.panorama.getPosition();
+      let bearing_deg = this.panorama.getPov().heading;
+      if (bearing_deg > 180) {
+        bearing_deg = bearing_deg - 360;
+      }
+      const new_position = await maps.jumpByDistanceAndBearing(
+        {lat: position.lat(), lng: position.lng()}, distance_km, bearing_deg);
+      if (new_position != null) {
+        console.log(
+          "Closest panorama is at lat: ", new_position.destination.lat,
+          "; lng: ", new_position.destination.lng,
+          "distance: ", new_position.distance_km);
+        this.panorama.setPosition(new_position.destination);
+      } else {
+        console.log("Can't find panorama in this direction.");
+      }
     },
   },
   mounted: function() {
     this.panorama = new google.maps.StreetViewPanorama(
       document.getElementById('street-view-anchor'),
       {
-        position: this.mapPosition,
+        position: this.initialMapPosition,
         pov: DEFAULT_POV,
         zoom: 1,
         addressControl: false,
@@ -78,16 +162,23 @@ export default {
         panControl: true,
       },
     );
+    this.panorama.addListener("position_changed", () => {
+      const pos = this.panorama.getPosition();
+      this.mapPosition = pos.toJSON();
+      console.log("Position changed in streetview:", this.mapPosition);
+    });
   },
   watch: {
+    initialMapPosition: function(newValue, oldValue) {
+      console.log(
+        "initialMapPosition changed, forcing streetview position to: ",
+        newValue);
+      this.panorama.setPosition(newValue);
+    },
     mapPosition: function(newValue, oldValue) {
-      // this is stupid, why do I even bother...
-      if (JSON.stringify(oldValue) != JSON.stringify(newValue)) {
-        this.$nextTick(function() {
-          this.panorama.setPosition(this.mapPosition);
-          this.panorama.setPov(DEFAULT_POV);
-        });
-      }
+      console.log(
+        "mapPosition changed to", newValue, "emitting position_changed");
+      this.$emit('position_changed', newValue);
     },
   },
 };

--- a/src/game_gen/game_generator.js
+++ b/src/game_gen/game_generator.js
@@ -89,7 +89,7 @@ export class GameGenerator {
       p = this.kmlPoints.pop(); 
     }
 
-    let actualPosition = await maps.getClosestPanorama(p, 100);
+    let actualPosition = await maps.getClosestPanorama({lat: p[1], lng: p[0]}, 100);
     if (actualPosition) return actualPosition;
     return null;
   }
@@ -175,7 +175,7 @@ export class GameGenerator {
         );
       }
       rounds[i] = {
-        map_position: position.toJSON(),
+        map_position: position,
       };
     }
 
@@ -220,8 +220,9 @@ export class GameGenerator {
         point = randomPoint(1).features[0];
       }
       if (this.cancelled) throw new CancelledError();
+      const coords = point.geometry.coordinates;
       let actualPosition = await maps.getClosestPanorama(
-        point.geometry.coordinates,
+        {lat: coords[1], lng: coords[0]}
       );
       if (actualPosition) {
         return actualPosition;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,12 +25,20 @@ const routes = [
       import(/* webpackChunkName: "lobby" */ '@/views/Lobby.vue'),
   },
   {
-    path: '/game/:roomId',
-    name: 'game',
+    path: '/classic/:roomId',
+    name: 'classic',
     // route level code-splitting
     // this generates a separate chunk (about.[hash].js) for this route
     // which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "game" */ '@/views/Game.vue'),
+    component: () => import(/* webpackChunkName: "game" */ '@/views/ClassicGame.vue'),
+  },
+  {
+    path: '/rendezvous/:roomId',
+    name: 'rendezvous',
+    // route level code-splitting
+    // this generates a separate chunk (about.[hash].js) for this route
+    // which is lazy-loaded when the route is visited.
+    component: () => import(/* webpackChunkName: "rendezvous" */ '@/views/RendezvousGame.vue'),
   },
   {
     path: '*',

--- a/src/store/modules/experiment.store.js
+++ b/src/store/modules/experiment.store.js
@@ -1,0 +1,23 @@
+import Cookies from 'js-cookie';
+
+const state = {
+};
+
+const getters = {
+  getRendezvousEnabled(state) {
+    return Cookies.get('rendezvous_enabled') == "true";
+  },
+};
+
+const mutations = {
+  setRendezvousEnabled(state, value) {
+    Cookies.set('rendezvous_enabled', value);
+  },
+};
+
+export default {
+  namespaced: true,
+  getters,
+  state,
+  mutations,
+};

--- a/src/store/modules/game_gen.store.js
+++ b/src/store/modules/game_gen.store.js
@@ -15,8 +15,9 @@ const mutations = {
   setNewGameGenerator(state, { gameGenerator }) {
     state.gameGenerator = gameGenerator;
   },
-  startGameGenerator(state, { shapeNames, kmlUrl }) {
-    state.gameGenerator.startGeneration(shapeNames, kmlUrl);
+  startGameGenerator(state, { gameMode, shapeNames, kmlUrl, players }) {
+    state.gameGenerator.startGeneration(
+      gameMode, shapeNames, kmlUrl, players);
   },
   cancelCurrentGenerator(state) {
     state.gameGenerator.cancel();
@@ -41,7 +42,13 @@ const mutations = {
   },
   setKmlUrl(state, kmlUrl) {
     state.kmlUrl = kmlUrl;
-  }
+  },
+  setGameMode(state, gameMode) {
+    state.gameMode = gameMode;
+  },
+  setPlayers(state, players) {
+    state.players = players;
+  },
 };
 
 const actions = {
@@ -87,8 +94,10 @@ const actions = {
       }
     }
     commit('startGameGenerator', {
+      gameMode: state.gameMode,
       shapeNames: state.currentlySelectedShapes,
       kmlUrl: state.kmlUrl,
+      players: state.players,
     });
   },
   async waitToFinishGeneration({ state, commit }) {

--- a/src/store/modules/index.js
+++ b/src/store/modules/index.js
@@ -4,12 +4,14 @@
  */
 import auth from './auth.store';
 import dialog from './dialog.store';
+import experiment from './experiment.store';
 import gameGen from './game_gen.store';
 import persistentDialog from './persistent_dialog.store';
 
 const modules = {
   auth,
   dialog,
+  experiment,
   gameGen,
   persistentDialog,
 };

--- a/src/views/ClassicGame.vue
+++ b/src/views/ClassicGame.vue
@@ -62,6 +62,7 @@
       <MarkerMap
         @on-guess="guess($event)"
         v-bind:deadlineTimestamp="deadlineTimestamp"
+        v-bind:guessingEnabled="true"
       />
     </div>
     <PersistentDialog />
@@ -114,7 +115,6 @@
 
 <script>
 import firebase from 'firebase/app';
-import 'firebase/database';
 
 // This is the main view for the actual game.
 import Streets from '@/components/Streets.vue';
@@ -131,7 +131,7 @@ import { mapMutations } from 'vuex';
 var roomState = {};
 
 export default {
-  name: 'Game',
+  name: 'ClassicGame',
   components: {
     Dialog,
     Streets,

--- a/src/views/Game.vue
+++ b/src/views/Game.vue
@@ -54,7 +54,10 @@
       v-bind:playerGuessStatus="players"
       v-bind:isChief="isChief()"
     />
-    <Streets v-bind:mapPosition="mapPosition" />
+    <Streets
+      v-bind:initialMapPosition="mapPosition"
+      v-bind:jumpButtonsEnabled=false
+    />
     <div id="map-overlay">
       <MarkerMap
         @on-guess="guess($event)"

--- a/src/views/Lobby.vue
+++ b/src/views/Lobby.vue
@@ -213,6 +213,7 @@ export default {
           }
           this.chief = chiefSnapshot.val();
         });
+        let gameModeDbRef = roomRef.child('options').child('game_mode');
         this.startedDbRef = roomRef.child('started');
         this.startedDbRef.on('value', startedSnapshot => {
           if (!startedSnapshot.exists()) {
@@ -225,9 +226,19 @@ export default {
             });
           }
           if (startedSnapshot.val() === true) {
-            this.cleanUpAndChangeView({
-              name: 'game',
-              params: { roomId: this.$route.params.roomId },
+            gameModeDbRef.once('value').then(gameMode => {
+              if (gameMode.val() != 'classic' && gameMode.val() != 'rendezvous') {
+                this.showDialog({
+                  title: `Game mode ${gameMode.val()} unknown`,
+                  text:
+                    "Room you are trying to access doesn't have a game mode set. " +
+                    'Create a new room.',
+                });
+              }
+              this.cleanUpAndChangeView({
+                name: gameMode.val(),
+                params: { roomId: this.$route.params.roomId },
+              });
             });
           }
         });

--- a/src/views/Lobby.vue
+++ b/src/views/Lobby.vue
@@ -266,6 +266,7 @@ export default {
       'showPersistentDialog',
       'hidePersistentDialog',
     ]),
+    ...mapMutations('gameGen', ['setPlayers']),
     ...mapMutations('dialog', ['showDialog']),
   },
   computed: {
@@ -337,6 +338,14 @@ export default {
         console.error('We lost "chief" status! This should never happen!');
       }
       this.triggerGameRegeneration({ roomPath: roomObjectPath(this.roomId) });
+    },
+    connected_players: function(newVal) {
+      this.setPlayers(this.connected_players);
+      if (!this.isChief) {
+        this.triggerGameRegeneration({
+          roomPath: roomObjectPath(this.roomId),
+        });
+      }
     },
   },
   unmounted: function() {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -144,6 +144,9 @@ export default {
         finished: false,
         players: {},
         current_round: 0,
+        options: {
+          game_mode: "classic",
+        },
       };
       roomObject.players[uid] = {
         username: username,

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -1,0 +1,24 @@
+<template>
+  <div id="game-view-container">
+    This isn't the game mode you're looking for.
+    Move along.
+    <PersistentDialog />
+    <Dialog />
+  </div>
+</template>
+
+<style scoped>
+</style>
+
+<script>
+import Dialog from '@/components/Dialog';
+import PersistentDialog from '@/components/PersistentDialog';
+
+export default {
+  name: 'RendezvousGame',
+  components: {
+    Dialog,
+    PersistentDialog,
+  },
+};
+</script>


### PR DESCRIPTION
This is a change for #37 to allow more easily to enable/disable rendezvous and experiment with it.
All changes up to #41 are prerequisites.

Screenshot for how to enable:
![rendezvous_experiment_ui](https://user-images.githubusercontent.com/802495/110259931-60322900-7faa-11eb-89d3-6bcfb906478b.jpg)
Description copied from the CL:
The idea behind this change is to allow one to gate
experimental features behind a cookie-based flag.
The flag can easily be set or unset in the vue devtools
(though the method is a bit obtuse).
To do this:
1. Open the Vue devtools plugin.
2. Find the Header component.
3. Click it, it should become green and a "= $vm0" should show up
next to it.
4. In the console type $vm0.setRendezvousEnabled(true);
5. Refresh the page.
Rendezvous should now be persistently enabled (even after page
refreshes, since the experiment is stored in cookies). The header
will change its color and text to make this more visible.
To disable the experiment, just use the same process as above,
only changing the call to set to false.