### PR TITLE
First working rendezvous game implementation

### DIFF
--- a/src/components/LobbyOptions.vue
+++ b/src/components/LobbyOptions.vue
@@ -269,8 +269,12 @@ export default {
     },
     ...mapActions('gameGen', ['triggerGameRegeneration']),
     ...mapMutations('gameGen', [
-      'setAvailableShapes', 'setSelectedShapes', 'setKmlUrl',
-      'setGameMode', 'setPlayers']),
+      'setAvailableShapes',
+      'setSelectedShapes',
+      'setKmlUrl',
+      'setGameMode',
+      'setPlayers',
+    ]),
   },
   mounted: function() {
     this.watchOptionsChanges();

--- a/src/components/MarkerMap.vue
+++ b/src/components/MarkerMap.vue
@@ -1,7 +1,8 @@
 <template>
   <div id="marker-map-container">
     <div id="map-anchor" />
-    <v-btn tile color="accent" v-on:click="guess()" class="white--text">
+    <v-btn tile color="accent" v-if="guessingEnabled"
+           v-on:click="guess()" class="white--text">
       Make a guess
       <p v-if="deadlineTimestamp != null">({{ timeLeft.toFixed(0) }}s)</p>
     </v-btn>
@@ -36,6 +37,10 @@ export default {
       type: Number,
       required: false,
     },
+    guessingEnabled: {
+      type: Boolean,
+      required: false,
+    },
   },
   data: function() {
     return {
@@ -65,6 +70,7 @@ export default {
         map: this.map,
         title: 'My guess',
       });
+      this.$emit('on-click', this.marker.position.toJSON());
     });
     this.timerCallback = setInterval(() => {
       if (this.deadlineTimestamp != null) {

--- a/src/components/MarkerMap.vue
+++ b/src/components/MarkerMap.vue
@@ -1,8 +1,13 @@
 <template>
   <div id="marker-map-container">
     <div id="map-anchor" />
-    <v-btn tile color="accent" v-if="guessingEnabled"
-           v-on:click="guess()" class="white--text">
+    <v-btn
+      tile
+      color="accent"
+      v-if="guessingEnabled"
+      v-on:click="guess()"
+      class="white--text"
+    >
       Make a guess
       <p v-if="deadlineTimestamp != null">({{ timeLeft.toFixed(0) }}s)</p>
     </v-btn>

--- a/src/components/RendezvousResults.vue
+++ b/src/components/RendezvousResults.vue
@@ -1,0 +1,130 @@
+<template>
+  <div id="rendezvous-results" />
+</template>
+<style scoped>
+#rendezvous-results {
+  position: fixed;
+  width: 75vw;
+  height: 75vh;
+  overflow: hidden;
+  max-height: calc(90vh - 150px);
+}
+</style>
+
+<script>
+/*global google*/
+import sanitizeHtml from 'sanitize-html';
+import colors from 'vuetify/lib/util/colors';
+import maps_util from '../maps_util';
+
+export default {
+  props: {
+    players: {
+      type: Object,
+      required: true,
+    },
+    player_data: {
+      type: Object,
+      required: true,
+    },
+  },
+  data: function() {
+    return {};
+  },
+  name: 'RendezvousResults',
+  methods: {
+    wipeMarkers: function() {
+      if (this.markers !== undefined) {
+        this.markers.forEach(e => {
+          e.setMap(null);
+        });
+      }
+      this.markers = [];
+    },
+    mountMap: function() {
+      this.map = new google.maps.Map(
+        document.getElementById('rendezvous-results'),
+        {
+          zoom: 1,
+          center: new google.maps.LatLng(0, 0),
+          disableDefaultUI: true,
+        },
+      );
+
+      this.markers = [];
+    },
+    randomElement: function(arr) {
+      return arr[Math.floor(Math.random() * arr.length)];
+    },
+    randomColor: function() {
+      let color_group = this.randomElement(Object.values(colors));
+      return color_group.base;
+    },
+    refreshMarkers: function() {
+      this.wipeMarkers();
+      this.mountMap();
+
+      if (this.players == null || this.player_data == null) {
+        console.log('Players or player_data is missing');
+        return;
+      }
+      const final_positions = [];
+      for (const key of Object.keys(this.players)) {
+        const username = this.players[key].username;
+        const map_position = this.player_data[key].map_position;
+        final_positions.push(map_position);
+        const sanitizedUsername = sanitizeHtml(username, {
+          allowedTags: [],
+          allowedAttributes: {},
+          disallowedTagsMode: 'recursiveEscape',
+        });
+        const position_history = this.player_data[key].position_history;
+        const starting_position = position_history[0];
+        const startMarker = new google.maps.Marker({
+          position: starting_position,
+          map: this.map,
+          title: `Start for ${username}`,
+          label: `Start for ${username}`,
+        });
+        this.markers.push(startMarker);
+        let deduped_history = [starting_position];
+        let total_distance = 0;
+        let last_position = starting_position;
+        for (const position of Object.values(position_history)) {
+          if (deduped_history[deduped_history.length - 1] == position) {
+            continue;
+          }
+          deduped_history.push(position);
+          total_distance += maps_util.haversine_distance(
+            last_position,
+            position,
+          );
+          last_position = position;
+        }
+        const info = new google.maps.InfoWindow({
+          content: `${sanitizedUsername}: ${total_distance.toFixed(2)} km`,
+        });
+        info.open(this.map, startMarker);
+        let color = this.randomColor();
+        const line = new google.maps.Polyline({
+          path: deduped_history,
+          map: this.map,
+          strokeColor: color,
+        });
+        this.markers.push(line);
+      }
+      const final_center_point = maps_util.centerPoint(final_positions);
+      const endMarker = new google.maps.Marker({
+        position: final_center_point,
+        map: this.map,
+        title: `Rendevous point`,
+        label: `Rendevous point`,
+      });
+      this.markers.push(endMarker);
+    },
+  },
+  mounted: function() {
+    this.refreshMarkers();
+  },
+};
+</script>

--- a/src/components/RendezvousResults.vue
+++ b/src/components/RendezvousResults.vue
@@ -15,7 +15,7 @@
 /*global google*/
 import sanitizeHtml from 'sanitize-html';
 import colors from 'vuetify/lib/util/colors';
-import maps_util from '../maps_util';
+import maps_util from '@/maps_util';
 
 export default {
   props: {
@@ -29,7 +29,9 @@ export default {
     },
   },
   data: function() {
-    return {};
+    return {
+      markers: [],
+    };
   },
   name: 'RendezvousResults',
   methods: {
@@ -50,8 +52,6 @@ export default {
           disableDefaultUI: true,
         },
       );
-
-      this.markers = [];
     },
     randomElement: function(arr) {
       return arr[Math.floor(Math.random() * arr.length)];
@@ -65,7 +65,7 @@ export default {
       this.mountMap();
 
       if (this.players == null || this.player_data == null) {
-        console.log('Players or player_data is missing');
+        console.error('Players or player_data is missing');
         return;
       }
       const final_positions = [];

--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -18,7 +18,8 @@
         elevation="0"
         color="secondary"
         @click="jump(500)"
-      >500km</v-btn>
+        >500km</v-btn
+      >
       <v-btn
         id="jump-button-50"
         class="jump-button"
@@ -26,7 +27,8 @@
         elevation="0"
         color="secondary"
         @click="jump(50)"
-      >50km</v-btn>
+        >50km</v-btn
+      >
       <v-btn
         id="jump-button-10"
         class="jump-button"
@@ -34,7 +36,8 @@
         elevation="0"
         color="secondary"
         @click="jump(10)"
-      >10km</v-btn>
+        >10km</v-btn
+      >
       <v-btn
         id="jump-button-1"
         class="jump-button"
@@ -42,7 +45,8 @@
         elevation="0"
         color="secondary"
         @click="jump(1)"
-      >1km</v-btn>
+        >1km</v-btn
+      >
     </v-container>
     <div id="street-view-anchor" />
   </div>
@@ -134,12 +138,19 @@ export default {
         bearing_deg = bearing_deg - 360;
       }
       const new_position = await maps.jumpByDistanceAndBearing(
-        {lat: position.lat(), lng: position.lng()}, distance_km, bearing_deg);
+        { lat: position.lat(), lng: position.lng() },
+        distance_km,
+        bearing_deg,
+      );
       if (new_position != null) {
         console.log(
-          "Closest panorama is at lat: ", new_position.destination.lat,
-          "; lng: ", new_position.destination.lng,
-          "distance: ", new_position.distance_km);
+          'Closest panorama is at lat: ',
+          new_position.destination.lat,
+          '; lng: ',
+          new_position.destination.lng,
+          'distance: ',
+          new_position.distance_km,
+        );
         this.panorama.setPosition(new_position.destination);
       } else {
         console.log("Can't find panorama in this direction.");
@@ -162,22 +173,26 @@ export default {
         panControl: true,
       },
     );
-    this.panorama.addListener("position_changed", () => {
+    this.panorama.addListener('position_changed', () => {
       const pos = this.panorama.getPosition();
       this.mapPosition = pos.toJSON();
-      console.log("Position changed in streetview:", this.mapPosition);
+      console.log('Position changed in streetview:', this.mapPosition);
     });
   },
   watch: {
-    initialMapPosition: function(newValue, oldValue) {
+    initialMapPosition: function(newValue) {
       console.log(
-        "initialMapPosition changed, forcing streetview position to: ",
-        newValue);
+        'initialMapPosition changed, forcing streetview position to: ',
+        newValue,
+      );
       this.panorama.setPosition(newValue);
     },
-    mapPosition: function(newValue, oldValue) {
+    mapPosition: function(newValue) {
       console.log(
-        "mapPosition changed to", newValue, "emitting position_changed");
+        'mapPosition changed to',
+        newValue,
+        'emitting position_changed',
+      );
       this.$emit('position_changed', newValue);
     },
   },

--- a/src/views/ClassicGame.vue
+++ b/src/views/ClassicGame.vue
@@ -62,6 +62,7 @@
       <MarkerMap
         @on-guess="guess($event)"
         v-bind:deadlineTimestamp="deadlineTimestamp"
+        v-bind:guessingEnabled=true
       />
     </div>
     <PersistentDialog />

--- a/src/views/ClassicGame.vue
+++ b/src/views/ClassicGame.vue
@@ -56,13 +56,13 @@
     />
     <Streets
       v-bind:initialMapPosition="mapPosition"
-      v-bind:jumpButtonsEnabled=false
+      v-bind:jumpButtonsEnabled="false"
     />
     <div id="map-overlay">
       <MarkerMap
         @on-guess="guess($event)"
         v-bind:deadlineTimestamp="deadlineTimestamp"
-        v-bind:guessingEnabled=true
+        v-bind:guessingEnabled="true"
       />
     </div>
     <PersistentDialog />

--- a/src/views/Lobby.vue
+++ b/src/views/Lobby.vue
@@ -88,13 +88,6 @@ import Dialog from '@/components/Dialog';
 import PersistentDialog from '@/components/PersistentDialog';
 import { roomObjectPath, signInGuard, roomGuard } from '@/firebase_utils.js';
 
-export class GameCreationError extends Error {
-  constructor() {
-    super('Failed to create the game.');
-    this.name = 'GameCreationError';
-  }
-}
-
 export default {
   name: 'Lobby',
   data: function() {
@@ -218,7 +211,10 @@ export default {
           }
           if (startedSnapshot.val() === true) {
             this.gameModeDbRef.once('value').then(gameMode => {
-              if (gameMode.val() != 'classic' && gameMode.val() != 'rendezvous') {
+              if (
+                gameMode.val() != 'classic' &&
+                gameMode.val() != 'rendezvous'
+              ) {
                 this.showDialog({
                   title: `Game mode ${gameMode.val()} unknown`,
                   text:
@@ -240,8 +236,8 @@ export default {
     },
     async ensureGameGeneratedAndStart() {
       try {
-        await this.waitToFinishGeneration()
-      } catch(error) {
+        await this.waitToFinishGeneration();
+      } catch (error) {
         this.startingGame = false;
         this.forceRegenerationOnStartGame = true;
         this.showDialog({
@@ -255,21 +251,20 @@ export default {
         return;
       }
       let game_mode = await this.gameModeDbRef.once('value');
-      if (game_mode.val() == "rendezvous") {
+      if (game_mode.val() == 'rendezvous') {
         if (Object.keys(this.connected_players).length < 2) {
           this.startingGame = false;
           this.forceRegenerationOnStartGame = true;
           this.showDialog({
             title: 'Rendezvous needs at least 2 players',
-            text:
-              "Currently no single-player mode is implemented. Sorry :(",
+            text: 'Currently no single-player mode is implemented. Sorry :(',
           });
           return;
         }
       }
       try {
         this.startedDbRef.set(true);
-      } catch(error) {
+      } catch (error) {
         this.startingGame = false;
         this.forceRegenerationOnStartGame = true;
         console.log(error);

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -145,7 +145,7 @@ export default {
         players: {},
         current_round: 0,
         options: {
-          game_mode: "classic",
+          game_mode: 'classic',
         },
       };
       roomObject.players[uid] = {

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -1,24 +1,318 @@
 <template>
   <div id="game-view-container">
-    This isn't the game mode you're looking for.
-    Move along.
+    <v-overlay :value="finished" id="win-overlay">
+      <v-card light height="100%">
+        <v-card-title>
+          Results
+        </v-card-title>
+        <v-container>
+          <RendezvousResults
+            v-bind:players="players"
+            v-bind:player_data="playerData"
+          />
+        </v-container>
+        <v-card-actions class="card-bottom">
+          <v-btn
+            class="white--text"
+            color="accent"
+            v-if="isChief()"
+            v-on:click="restartGame()"
+          >
+            Restart game
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-overlay>
+    <PlayerList
+      @on-kick-player="kickPlayer($event)"
+      v-bind:playerGuessStatus="players"
+      v-bind:isChief="isChief()"
+    />
+    <Streets
+      v-bind:initialMapPosition="initialMapPosition"
+      v-on:position_changed="positionChanged($event)"
+      v-bind:jumpButtonsEnabled="true"
+    />
+    <div id="map-overlay">
+      <MarkerMap @on-click="teleport($event)" v-bind:guessingEnabled="false" />
+    </div>
     <PersistentDialog />
     <Dialog />
   </div>
 </template>
 
 <style scoped>
+#game-view-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  position: absolute;
+}
+
+#map-overlay {
+  position: absolute;
+  width: 400px;
+  height: 200px;
+  left: 0;
+
+  bottom: 0;
+  background-color: rgba(145, 10, 172, 0.5);
+  z-index: 2;
+  cursor: pointer;
+  display: block;
+  scale: 0.5;
+
+  transition: all 0.2s ease-in-out;
+}
+
+#map-overlay:hover {
+  width: 90%;
+  height: 90%;
+}
+
+#win-overlay >>> .v-overlay__content {
+  width: 80vw;
+  height: 90vh;
+}
+
+.card-bottom {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
 </style>
 
 <script>
+import firebase from 'firebase/app';
+
+// This is the main view for the actual game.
+import Streets from '@/components/Streets.vue';
+import MarkerMap from '@/components/MarkerMap.vue';
+import PlayerList from '@/components/PlayerList.vue';
 import Dialog from '@/components/Dialog';
 import PersistentDialog from '@/components/PersistentDialog';
+import RendezvousResults from '@/components/RendezvousResults';
+import { roomObjectPath, signInGuard, roomGuard } from '@/firebase_utils.js';
+import { mapMutations } from 'vuex';
+import maps_util from '../maps_util';
+
+var roomState = {};
 
 export default {
   name: 'RendezvousGame',
   components: {
     Dialog,
+    Streets,
+    MarkerMap,
+    PlayerList,
     PersistentDialog,
+    RendezvousResults,
+  },
+  data: function() {
+    return {
+      initialMapPosition: { lat: 37.75598, lng: -122.41231 },
+      initialMapPositionSet: false,
+      finished: false,
+      roomState: {},
+      players: {},
+      playerData: {},
+      currentChief: '',
+      timeLimit: null,
+      teleportEnabled: false,
+    };
+  },
+  mounted: function() {
+    this.showPersistentDialog({
+      text: 'Connecting...',
+    });
+    signInGuard(this.$store)
+      .catch(error => {
+        console.log('Error getting user UID:', error);
+        this.showPersistentDialog({
+          text: 'Unable to connect to Firebase :/ Try refreshing later.',
+        });
+      })
+      .then(() => {
+        const uid = this.$store.state.auth.uid;
+        return roomGuard(this.roomId, uid);
+      })
+      .then(() => {
+        this.hidePersistentDialog();
+        this.refreshPage();
+      })
+      .catch(error_room => {
+        if (error_room === null) {
+          // Room doesn't exist.
+          this.showDialog({
+            title: "Room doesn't exist",
+            text:
+              "Room you are trying to access doesn't exist. " +
+              'Use correct link or create a new room.',
+            confirmAction: function() {
+              this.cleanUpAndChangeView({ name: 'main' });
+            },
+          });
+        } else {
+          // User is not in the room. Redirect them to the join link.
+          this.cleanUpAndChangeView({
+            name: 'join',
+            params: { roomId: this.roomId },
+          });
+        }
+      });
+  },
+  computed: {
+    roomDbRef: function() {
+      return firebase.database().ref(this.roomDbPath);
+    },
+    roomDbPath: function() {
+      return roomObjectPath(this.roomId);
+    },
+    roomId: function() {
+      return this.$route.params.roomId;
+    },
+  },
+  methods: {
+    refreshPage: function() {
+      function cb(snapshot) {
+        roomState = snapshot.val();
+
+        if (!roomState.started) {
+          this.cleanUpAndChangeView({ name: 'lobby' });
+          return;
+        }
+
+        this.currentChief = roomState.chief;
+
+        this.playerData = roomState.rendezvous_data.player_data;
+        this.finished = roomState.rendezvous_data.finished;
+        if (!this.initialMapPositionSet) {
+          // The first time after loading the game we want to update the streetview position.
+          // Afterwards the database is always secondary to streetview.
+          this.initialMapPosition = this.playerData[
+            this.$store.state.auth.uid
+          ].map_position;
+          this.positionHistory = this.playerData[
+            this.$store.state.auth.uid
+          ].position_history;
+          this.initialMapPositionSet = true;
+        }
+
+        if (!this.players) {
+          this.players = [];
+        }
+        this.players = roomState.players;
+        if (!this.finished && this.isChief()) {
+          this.updateFinished();
+        }
+      }
+      this.roomDbRef.on('value', cb.bind(this));
+    },
+    positionChanged: function(event) {
+      const position = { lat: event.lat, lng: event.lng };
+      if (!this.initialMapPositionSet) {
+        console.log('Received position event before initial position sync.');
+        return;
+      }
+      this.positionHistory.push(position);
+      this.roomDbRef
+        .child('rendezvous_data')
+        .child('player_data')
+        .child(this.$store.state.auth.uid)
+        .set(
+          { map_position: position, position_history: this.positionHistory },
+          error => {
+            if (error) {
+              console.log(error);
+              this.$emit(
+                'firebase_error',
+                "Couldn't modify map position in database.",
+              );
+            }
+          },
+        );
+    },
+    cleanUpAndChangeView(location) {
+      this.roomDbRef.off();
+      this.$router.push(location);
+    },
+    updateFinished: function() {
+      if (this.finished) {
+        return;
+      }
+      if (this.playerData == null) {
+        return;
+      }
+      if (Object.keys(this.playerData).length <= 1) return false;
+      let max_distance_km = 0;
+      for (const player_1 of Object.values(this.playerData)) {
+        for (const player_2 of Object.values(this.playerData)) {
+          let distance_km = maps_util.haversine_distance(
+            player_1.map_position,
+            player_2.map_position,
+          );
+          console.log('Distance:', player_1, player_2, distance_km);
+          max_distance_km = Math.max(max_distance_km, distance_km);
+        }
+      }
+      if (max_distance_km > 0.01) {
+        return;
+      }
+      // Within 10m.
+      this.roomDbRef
+        .child('rendezvous_data')
+        .child('finished')
+        .set(true, error => {
+          if (error) {
+            console.log(error);
+            this.$emit(
+              'firebase_error',
+              "Couldn't modify 'finished' in database.",
+            );
+          }
+        });
+    },
+    async teleport(newPosition) {
+      if (!this.teleportEnabled) {
+        return;
+      }
+      console.log('Teleport to ', newPosition);
+      const newStreetviewPosition = await maps_util.getClosestPanorama(
+        newPosition,
+      );
+      console.log('Found: ', newStreetviewPosition);
+      if (newStreetviewPosition != null) {
+        this.initialMapPosition = newStreetviewPosition;
+      }
+    },
+    isChief() {
+      return this.$store.state.auth.uid == this.currentChief;
+    },
+    async restartGame() {
+      const snapshot = await this.roomDbRef.once('value');
+      const roomState = snapshot.val();
+      roomState.started = false;
+      this.roomDbRef.set(roomState).catch(error => {
+        this.showDialog({
+          title: 'Could not restart the game',
+          text: error,
+        });
+      });
+    },
+    kickPlayer(event) {
+      const player_uuid = event.player_uuid;
+      this.roomDbRef
+        .child('players')
+        .child(player_uuid)
+        .remove();
+    },
+    ...mapMutations('persistentDialog', [
+      'showPersistentDialog',
+      'hidePersistentDialog',
+    ]),
+    ...mapMutations('dialog', ['showDialog']),
   },
 };
 </script>

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -96,7 +96,7 @@ import PersistentDialog from '@/components/PersistentDialog';
 import RendezvousResults from '@/components/RendezvousResults';
 import { roomObjectPath, signInGuard, roomGuard } from '@/firebase_utils.js';
 import { mapMutations } from 'vuex';
-import maps_util from '../maps_util';
+import maps_util from '@/maps_util';
 
 var roomState = {};
 
@@ -150,7 +150,7 @@ export default {
             text:
               "Room you are trying to access doesn't exist. " +
               'Use correct link or create a new room.',
-            confirmAction: function() {
+            confirmAction: () => {
               this.cleanUpAndChangeView({ name: 'main' });
             },
           });
@@ -303,10 +303,17 @@ export default {
     },
     kickPlayer(event) {
       const player_uuid = event.player_uuid;
-      this.roomDbRef
-        .child('players')
-        .child(player_uuid)
-        .remove();
+      if (Object.keys(this.players).length <= 2) {
+        this.showDialog({
+          title: "Can't kick two or fewer players left",
+          text: 'Create a new game instead',
+        });
+        return;
+      }
+      let updateDict = {};
+      updateDict[`players/${player_uuid}`] = null;
+      updateDict[`rendezvous_data/player_data/${player_uuid}`] = null;
+      this.roomDbRef.update(updateDict);
     },
     ...mapMutations('persistentDialog', [
       'showPersistentDialog',


### PR DESCRIPTION
For #37. Copied from CL description:
This change adds the rendezvous game mode.
Mostly the change adds a proper RendezvousGame view
and a RendezvousResults component.

Additionally a few changes to other components were needed:
* making a guess is unnecessary in rendezvous, so the MarkerMap
now displays the "make a guess" button conditioned on a prop.
* rendezvous currently makes no sense for single-player, so the Lobby
checks for this before starting the game.