### PR TITLE
Create support for showing a Toast, use it in Rendezvous

### DIFF
--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -104,6 +104,7 @@
 
 <script>
 import maps from '@/maps_util.js';
+import { mapActions, mapMutations } from 'vuex';
 
 /*global google*/
 
@@ -152,10 +153,25 @@ export default {
           new_position.distance_km,
         );
         this.panorama.setPosition(new_position.destination);
+        if (distance_km * 0.9 < new_position.distance_km && new_position.distance_km < distance_km * 1.1) {
+          this.showToast({
+            text: `Jumped ${new_position.distance_km.toFixed(2)}km`,
+          });
+        } else {
+          this.showToast({
+            text: `Jump was imprecise: ${new_position.distance_km.toFixed(2)}km`,
+            color: "orange",
+          });
+        }
       } else {
         console.log("Can't find panorama in this direction.");
+        this.showToast({
+          text: "Failed to find panorama in this direction",
+          color: "red",
+        });
       }
     },
+    ...mapActions('toast', ['showToast']),
   },
   mounted: function() {
     this.panorama = new google.maps.StreetViewPanorama(

--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -155,11 +155,11 @@ export default {
         this.panorama.setPosition(new_position.destination);
         if (distance_km * 0.9 < new_position.distance_km && new_position.distance_km < distance_km * 1.1) {
           this.showToast({
-            text: `Jumped ${new_position.distance_km.toFixed(2)}km`,
+            text: `Jumped ${new_position.distance_km.toFixed(2)} km`,
           });
         } else {
           this.showToast({
-            text: `Jump was imprecise: ${new_position.distance_km.toFixed(2)}km`,
+            text: `Jump was imprecise: ${new_position.distance_km.toFixed(2)} km`,
             color: "orange",
           });
         }

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-snackbar v-model="visible" timeout="-1" v-bind:color="color">
+    {{ text }}
+  </v-snackbar>
+</template>
+
+<script>
+import { mapState, mapMutations } from 'vuex';
+
+export default {
+  name: 'Toast',
+  computed: {
+    visible: {
+      get() {
+        return this.$store.state.toast.visible;
+      },
+      set(value) {
+        this.setToastVisibility(value);
+      },
+    },
+    ...mapState({
+      text: state => state.toast.text,
+      color: state => state.toast.color,
+    }),
+  },
+  methods: {
+    ...mapMutations('toast', ['setToastVisibility']),
+  },
+};
+</script>

--- a/src/store/modules/index.js
+++ b/src/store/modules/index.js
@@ -6,12 +6,14 @@ import auth from './auth.store';
 import dialog from './dialog.store';
 import gameGen from './game_gen.store';
 import persistentDialog from './persistent_dialog.store';
+import toast from './toast.store';
 
 const modules = {
   auth,
   dialog,
   gameGen,
   persistentDialog,
+  toast,
 };
 
 export default modules;

--- a/src/store/modules/toast.store.js
+++ b/src/store/modules/toast.store.js
@@ -1,0 +1,51 @@
+const state = {
+  visible: false,
+  hide_timestamp_ms: 2000,
+  color: 'gray',
+  text: '',
+};
+
+const getters = {};
+
+const mutations = {
+  setToastVisibility(state, visible) {
+    state.visible = visible;
+  },
+  setToastHideTimestampMs(state, hide_timestamp_ms) {
+    state.hide_timestamp_ms = hide_timestamp_ms;
+  },
+  setToast(state, options) {
+    state.text = options.text || '';
+    state.color = options.color || 'gray';
+  },
+};
+
+const actions = {
+  // We need an action in order to be able to correctly set up the callback
+  // to change state after a timer (vuex doesn't like mutations having timers
+  // in them).
+  showToast({ state, commit }, options) {
+    const delay_ms = 2000;
+    const hide_timestamp_ms = Date.now() + delay_ms;
+    commit('setToast', options);
+    commit('setToastHideTimestampMs', hide_timestamp_ms);
+    commit('setToastVisibility', true);
+    setTimeout(() => {
+      // Snackbars support timers, but they don't support resetting the timer
+      // when the text changes, so we roll our own support here.
+      if (state.hide_timestamp_ms == hide_timestamp_ms) {
+        // We're still the active timer.
+        commit('setToastVisibility', false);
+      }
+      // Otherwise some other timer is active, so do nothing.
+    }, delay_ms);
+  },
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations,
+};

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -38,6 +38,7 @@
     </div>
     <PersistentDialog />
     <Dialog />
+    <Toast />
   </div>
 </template>
 
@@ -94,6 +95,7 @@ import PlayerList from '@/components/PlayerList.vue';
 import Dialog from '@/components/Dialog';
 import PersistentDialog from '@/components/PersistentDialog';
 import RendezvousResults from '@/components/RendezvousResults';
+import Toast from '@/components/Toast';
 import { roomObjectPath, signInGuard, roomGuard } from '@/firebase_utils.js';
 import { mapMutations } from 'vuex';
 import maps_util from '@/maps_util';
@@ -109,6 +111,7 @@ export default {
     PlayerList,
     PersistentDialog,
     RendezvousResults,
+    Toast,
   },
   data: function() {
     return {


### PR DESCRIPTION
This change adds support for a toast (a message that will display at the bottom of the screen for a short time).
This is used to warn players when their jump was imprecise or impossible, and to notify them of the length of their jump otherwise.
This change depends on #43. It's needed #37.