### PR TITLE
Timer and streetview marker support for Rendezvous, enable Rendezvous by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '@vue/cli-plugin-unit-jest',
+  transformIgnorePatterns: ['node_modules/(?!vuetify/lib/util/colors)'],
 };

--- a/src/components/LobbyOptions.vue
+++ b/src/components/LobbyOptions.vue
@@ -37,6 +37,26 @@
       </v-row>
       <v-row>
         <v-col>
+          <div
+            v-if="
+              gameMode == 'rendezvous' &&
+                selectedShapeNames.length == 0 &&
+                kmlUrl == ''
+            "
+          >
+            <span class="red--text">Warning:</span> for rendezvous to be
+            winnable the starting locations of all players must be connected
+            over streetview roads, but the location generation algorithm doesn't
+            take this into account. (E.g. if one player is in the Americas and
+            another in Asia, there is no way to win.) Select a location or
+            provide a KML URL below to decrease the chance of being in an
+            unwinnable game. You can use
+            <a
+              href="https://en.wikipedia.org/wiki/Coverage_of_Google_Street_View"
+              >wikipedia</a
+            >
+            as a guide to good starting locations.
+          </div>
           <v-autocomplete
             ref="shapesInput"
             v-model="selectedShapeNames"
@@ -104,7 +124,7 @@ export default {
       timeLimitSyncing: false,
       shapesInputSyncing: false,
       gameModeSyncing: false,
-      showGameModePicker: false,
+      showGameModePicker: true,
     };
   },
   computed: {

--- a/src/components/MarkerMap.vue
+++ b/src/components/MarkerMap.vue
@@ -9,8 +9,11 @@
       class="white--text"
     >
       Make a guess
-      <p v-if="deadlineTimestamp != null">({{ timeLeft.toFixed(0) }}s)</p>
+      <p v-if="deadlineTimestamp != null">(Time remaining: {{ timeLeft.toFixed(0) }}s)</p>
     </v-btn>
+    <v-system-bar tile color="red lighten" v-if="!guessingEnabled && deadlineTimestamp != null" class="white--text">
+      Time remaining: {{ timeLeft.toFixed(0) }}s
+    </v-system-bar>
     <!-- <button v-on:click="mathdebug()">Do some math!</button> !-->
   </div>
 </template>

--- a/src/components/MarkerMap.vue
+++ b/src/components/MarkerMap.vue
@@ -9,9 +9,16 @@
       class="white--text"
     >
       Make a guess
-      <p v-if="deadlineTimestamp != null">(Time remaining: {{ timeLeft.toFixed(0) }}s)</p>
+      <p v-if="deadlineTimestamp != null">
+        (Time remaining: {{ timeLeft.toFixed(0) }}s)
+      </p>
     </v-btn>
-    <v-system-bar tile color="red lighten" v-if="!guessingEnabled && deadlineTimestamp != null" class="white--text">
+    <v-system-bar
+      tile
+      color="red lighten"
+      v-if="!guessingEnabled && deadlineTimestamp != null"
+      class="white--text"
+    >
       Time remaining: {{ timeLeft.toFixed(0) }}s
     </v-system-bar>
     <!-- <button v-on:click="mathdebug()">Do some math!</button> !-->

--- a/src/components/RendezvousResults.vue
+++ b/src/components/RendezvousResults.vue
@@ -14,7 +14,6 @@
 <script>
 /*global google*/
 import sanitizeHtml from 'sanitize-html';
-import colors from 'vuetify/lib/util/colors';
 import maps_util from '@/maps_util';
 
 export default {
@@ -52,13 +51,6 @@ export default {
           disableDefaultUI: true,
         },
       );
-    },
-    randomElement: function(arr) {
-      return arr[Math.floor(Math.random() * arr.length)];
-    },
-    randomColor: function() {
-      let color_group = this.randomElement(Object.values(colors));
-      return color_group.base;
     },
     refreshMarkers: function() {
       this.wipeMarkers();
@@ -105,7 +97,7 @@ export default {
           content: `${sanitizedUsername}: ${total_distance.toFixed(2)} km`,
         });
         info.open(this.map, startMarker);
-        let color = this.randomColor();
+        let color = maps_util.colorForUuid(key);
         const line = new google.maps.Polyline({
           path: deduped_history,
           map: this.map,
@@ -117,8 +109,8 @@ export default {
       const endMarker = new google.maps.Marker({
         position: final_center_point,
         map: this.map,
-        title: `Rendevous point`,
-        label: `Rendevous point`,
+        title: `Rendezvous point`,
+        label: `Rendezvous point`,
       });
       this.markers.push(endMarker);
     },

--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -11,7 +11,7 @@
     >
       <v-icon large>mdi-anchor</v-icon>
     </v-btn>
-    <v-container v-if="jumpButtonsEnabled">
+    <div v-if="jumpButtonsEnabled">
       <v-btn
         id="jump-button-500"
         class="jump-button"
@@ -48,7 +48,7 @@
         @click="jump(1)"
         >1km</v-btn
       >
-    </v-container>
+    </div>
     <div id="street-view-anchor" />
   </div>
 </template>
@@ -106,7 +106,7 @@
 <script>
 import maps from '@/maps_util.js';
 import sanitizeHtml from 'sanitize-html';
-import { mapActions, mapMutations } from 'vuex';
+import { mapActions } from 'vuex';
 
 /*global google*/
 
@@ -164,28 +164,33 @@ export default {
           new_position.distance_km,
         );
         this.panorama.setPosition(new_position.destination);
-        if (distance_km * 0.9 < new_position.distance_km && new_position.distance_km < distance_km * 1.1) {
+        if (
+          distance_km * 0.9 < new_position.distance_km &&
+          new_position.distance_km < distance_km * 1.1
+        ) {
           this.showToast({
             text: `Jumped ${new_position.distance_km.toFixed(2)} km`,
           });
         } else {
           this.showToast({
-            text: `Jump was imprecise: ${new_position.distance_km.toFixed(2)} km`,
-            color: "orange",
+            text: `Jump was imprecise: ${new_position.distance_km.toFixed(
+              2,
+            )} km`,
+            color: 'orange',
           });
         }
       } else {
         console.log("Can't find panorama in this direction.");
         this.showToast({
-          text: "Failed to find panorama in this direction",
-          color: "red",
+          text: 'Failed to find panorama in this direction',
+          color: 'red',
         });
       }
     },
     wipeCurrentMarkers: function() {
       for (const marker of this.currentMarkers) {
         marker.setMap(null);
-      };
+      }
       this.currentMarkers = [];
     },
     ...mapActions('toast', ['showToast']),

--- a/src/game_gen/game_generator.js
+++ b/src/game_gen/game_generator.js
@@ -303,7 +303,7 @@ export class GameGenerator {
   }
 
   async generateValidPosition() {
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < 60; i++) {
       if (this.cancelled) throw new CancelledError();
       let point = null;
       if (this.shapes.length > 0) {

--- a/src/maps_util.js
+++ b/src/maps_util.js
@@ -1,3 +1,4 @@
+import colors from 'vuetify/lib/util/colors';
 import destination from '@turf/destination';
 
 const google = window.google;
@@ -160,6 +161,11 @@ class GoogleMapsWrapper {
       scores[player] = r;
     }
     return scores;
+  }
+
+  colorForUuid(user_uuid) {
+    const colorInd = user_uuid.charCodeAt(0) % Object.values(colors).length;
+    return Object.values(colors)[colorInd].base;
   }
 }
 

--- a/src/views/ClassicGame.vue
+++ b/src/views/ClassicGame.vue
@@ -57,6 +57,7 @@
     <Streets
       v-bind:initialMapPosition="mapPosition"
       v-bind:jumpButtonsEnabled="false"
+      v-bind:backToStartEnabled="true"
     />
     <div id="map-overlay">
       <MarkerMap


### PR DESCRIPTION
Required for #37 , requires PR #47 to be submitted.
Description copied from commit:
Rendezvous now respects the timer setting, ending the game when
the timer runs out.
We also display markers in the 3d panorama for all the players
(streetview only displays them when sufficiently close; empirically
the cutoff is about 300m).
The colors of the markers are deterministically chosen based on the
player uuid (the final results screen use the same colors).

Also, disables the "return to start" button in Rendezvous.
