### PR TITLE
Add undo button, reorder How To Play and player list

### DIFF
--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -48,6 +48,16 @@
         @click="jump(1)"
         >1km</v-btn
       >
+      <v-btn
+        id="undo-button"
+        class="jump-button"
+        fab
+        elevation="0"
+        color="secondary"
+        @click="undo()"
+      >
+        <v-icon large>mdi-undo-variant</v-icon>
+      </v-btn>
     </div>
     <div id="street-view-anchor" />
   </div>
@@ -80,6 +90,10 @@
 #back-to-position-button {
   width: 50px;
   height: 50px;
+}
+
+#undo-button {
+  bottom: 210px;
 }
 
 #jump-button-1 {
@@ -134,6 +148,7 @@ export default {
   data: function() {
     return {
       mapPosition: { lat: 37.75598, lng: -122.41231 },
+      undoMapPosition: null,
       currentMarkers: [],
     };
   },
@@ -193,6 +208,9 @@ export default {
       }
       this.currentMarkers = [];
     },
+    undo: function() {
+      this.panorama.setPosition(this.undoMapPosition);
+    },
     ...mapActions('toast', ['showToast']),
   },
   mounted: function() {
@@ -225,7 +243,12 @@ export default {
       );
       this.panorama.setPosition(newValue);
     },
-    mapPosition: function(newValue) {
+    mapPosition: function(newValue, oldValue) {
+      console.log("pos:", newValue, oldValue);
+      if (newValue.lat == oldValue.lat && newValue.lng == oldValue.lng) {
+        return;
+      }
+      this.undoMapPosition = oldValue;
       console.log(
         'mapPosition changed to',
         newValue,

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -19,7 +19,10 @@
           though: sometimes it won't be possible to find a streetview location
           in the direction you're facing, or you'll only be able to travel part
           of the requested distance, or you'll end up a bit off of where you
-          were aiming for.
+          were aiming for.<br />
+          If you make a mistake, or Streetview takes you somewhere you didn't
+          expect, you can fix this using the undo button (located underneath the
+          KM buttons). Note that it only allows you to undo a single movement.
           <h2>Minimap</h2>
           You can use the minimap in the lower left corner as a tool to help you
           figure out where you are. You can set a marker on it for convenience.
@@ -61,21 +64,27 @@
         </v-card-actions>
       </v-card>
     </v-overlay>
-    <v-row class="d-flex">
-      <PlayerList
-        @on-kick-player="kickPlayer($event)"
-        v-bind:playerGuessStatus="players"
-        v-bind:isChief="isChief()"
-      />
-      <v-btn
-        class="white--text"
-        small
-        color="accent"
-        v-on:click="instructionsVisible = true"
-      >
-        How to play
-      </v-btn>
-    </v-row>
+    <v-container class="pa-0 mx-3 my-0">
+      <v-row class="pa-0 ma-0">
+        <v-col class="flex-grow-0 flex-shrink-1 pa-0 ml-0 mr-3">
+          <v-btn
+            class="white--text"
+            small
+            color="accent"
+            v-on:click="instructionsVisible = true"
+          >
+            How to play
+          </v-btn>
+        </v-col>
+        <v-col class="flex-grow-1 flex-shrink-0 pa-0 ma-0">
+          <PlayerList
+            @on-kick-player="kickPlayer($event)"
+            v-bind:playerGuessStatus="players"
+            v-bind:isChief="isChief()"
+          />
+        </v-col>
+      </v-row>
+    </v-container>
     <Streets
       v-bind:initialMapPosition="initialMapPosition"
       v-on:position_changed="positionChanged($event)"


### PR DESCRIPTION
We now have an undo button, enabling us to jump back a single position.
The main purpose is to allow the player to fix missclicks.
We also make the How To Play button be on the left of the player list.