### PR TITLE
Fix bug in rendezvous, show Rendezvous point only on victory

### DIFF
--- a/src/components/LobbyOptions.vue
+++ b/src/components/LobbyOptions.vue
@@ -234,6 +234,7 @@ export default {
     isChief: function(newVal) {
       if (!newVal) {
         console.error('We lost "chief" status! This should never happen!');
+        return;
       }
       // Stop watching for option changes.
       this.roomOptionsRef.off();

--- a/src/components/RendezvousResults.vue
+++ b/src/components/RendezvousResults.vue
@@ -26,6 +26,10 @@ export default {
       type: Object,
       required: true,
     },
+    victory: {
+      type: Boolean,
+      required: true,
+    },
   },
   data: function() {
     return {
@@ -105,14 +109,16 @@ export default {
         });
         this.markers.push(line);
       }
-      const final_center_point = maps_util.centerPoint(final_positions);
-      const endMarker = new google.maps.Marker({
-        position: final_center_point,
-        map: this.map,
-        title: `Rendezvous point`,
-        label: `Rendezvous point`,
-      });
-      this.markers.push(endMarker);
+      if (this.victory) {
+        const final_center_point = maps_util.centerPoint(final_positions);
+        const endMarker = new google.maps.Marker({
+          position: final_center_point,
+          map: this.map,
+          title: `Rendezvous point`,
+          label: `Rendezvous point`,
+        });
+        this.markers.push(endMarker);
+      }
     },
   },
   mounted: function() {

--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -244,7 +244,7 @@ export default {
       this.panorama.setPosition(newValue);
     },
     mapPosition: function(newValue, oldValue) {
-      console.log("pos:", newValue, oldValue);
+      console.log('pos:', newValue, oldValue);
       if (newValue.lat == oldValue.lat && newValue.lng == oldValue.lng) {
         return;
       }

--- a/src/store/modules/persistent_dialog.store.js
+++ b/src/store/modules/persistent_dialog.store.js
@@ -15,7 +15,11 @@ const mutations = {
   },
 };
 
-const actions = {};
+const actions = {
+  hidePersistentDialogAction({ commit }) {
+    commit('hidePersistentDialog');
+  },
+};
 
 export default {
   namespaced: true,

--- a/src/views/Lobby.vue
+++ b/src/views/Lobby.vue
@@ -361,8 +361,8 @@ export default {
     },
     connected_players: function(newVal) {
       // We can find out that we're the chief after we find out the list of
-      // players, so it's important to fix keep the game generation store
-      // updated even if we're not the chief.
+      // players, so it's important to keep the game generation store updated
+      // even if we're not the chief.
       this.setPlayers(newVal);
       if (!this.isChief) {
         return;

--- a/src/views/Lobby.vue
+++ b/src/views/Lobby.vue
@@ -355,16 +355,21 @@ export default {
     isChief: function(newVal) {
       if (!newVal) {
         console.error('We lost "chief" status! This should never happen!');
+        return;
       }
       this.triggerGameRegeneration({ roomPath: roomObjectPath(this.roomId) });
     },
     connected_players: function(newVal) {
+      // We can find out that we're the chief after we find out the list of
+      // players, so it's important to fix keep the game generation store
+      // updated even if we're not the chief.
       this.setPlayers(newVal);
       if (!this.isChief) {
-        this.triggerGameRegeneration({
-          roomPath: roomObjectPath(this.roomId),
-        });
+        return;
       }
+      this.triggerGameRegeneration({
+        roomPath: roomObjectPath(this.roomId),
+      });
     },
   },
   unmounted: function() {

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -315,10 +315,11 @@ export default {
           this.deadlineTimerSet == null &&
           this.deadlineTimestamp != null
         ) {
-          setTimeout(
-            () => this.finishGame(false),
-            this.deadlineTimestamp - new Date().getTime(),
-          );
+          setTimeout(() => {
+            if (!this.checkForVictory()) {
+              this.finishGame(false);
+            }
+          }, this.deadlineTimestamp - new Date().getTime());
           this.deadlineTimerSet = true;
         }
 
@@ -362,10 +363,10 @@ export default {
     },
     checkForVictory: function() {
       if (this.finished) {
-        return;
+        return this.victory;
       }
       if (this.playerData == null) {
-        return;
+        return false;
       }
       if (Object.keys(this.playerData).length <= 1) return false;
       let max_distance_km = 0;
@@ -380,10 +381,11 @@ export default {
         }
       }
       if (max_distance_km > 0.01) {
-        return;
+        return false;
       }
       // Within 10m.
       this.finishGame(true);
+      return true;
     },
     finishGame: function(victory) {
       if (this.finished) {
@@ -442,12 +444,8 @@ export default {
       updateDict[`rendezvous_data/player_data/${player_uuid}`] = null;
       this.roomDbRef.update(updateDict);
     },
-    ...mapMutations('persistentDialog', [
-      'showPersistentDialog',
-    ]),
-    ...mapActions('persistentDialog', [
-      'hidePersistentDialogAction',
-    ]),
+    ...mapMutations('persistentDialog', ['showPersistentDialog']),
+    ...mapActions('persistentDialog', ['hidePersistentDialogAction']),
     ...mapMutations('dialog', ['showDialog']),
   },
 };


### PR DESCRIPTION
The bug was that we triggered game generation sometimes not in the
chief. Also use an action to hide the persistent dialog, which
seems to reduce the frequency with which the dialog
persists when it shouldn't.