### PR TITLE
Fix PersistentDialog and Dialog to not lock the game

### DIFF
--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog max-width="60vw" v-model="visible">
+  <v-overlay :value="visible" max-width="60vw">
     <v-card>
       <v-card-title class="headline">
         {{ title }}
@@ -15,7 +15,7 @@
         </v-btn>
       </v-card-actions>
     </v-card>
-  </v-dialog>
+  </v-overlay>
 </template>
 
 <script>

--- a/src/components/PersistentDialog.vue
+++ b/src/components/PersistentDialog.vue
@@ -1,12 +1,11 @@
 <template>
-  <v-dialog persistent max-width="60vw" v-model="visible">
+  <v-overlay :value="visible" max-width="60vw">
     <v-card>
-      <v-card-title></v-card-title>
       <v-card-text>
         {{ text }}
       </v-card-text>
     </v-card>
-  </v-dialog>
+  </v-overlay>
 </template>
 
 <script>

--- a/src/store/modules/toast.store.js
+++ b/src/store/modules/toast.store.js
@@ -1,6 +1,6 @@
 const state = {
   visible: false,
-  hide_timestamp_ms: 2000,
+  hide_timestamp_ms: 0,
   color: 'gray',
   text: '',
 };

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -433,7 +433,7 @@ export default {
       const player_uuid = event.player_uuid;
       if (Object.keys(this.players).length <= 2) {
         this.showDialog({
-          title: "Can't kick two or fewer players left",
+          title: "Can't kick when two or fewer players left",
           text: 'Create a new game instead',
         });
         return;

--- a/tests/unit/dialog_tests.spec.js
+++ b/tests/unit/dialog_tests.spec.js
@@ -43,13 +43,13 @@ describe('Dialog', () => {
 
   it('not renered by default', () => {
     const wrapper = mountDialog({});
-    expect(wrapper.find('.v-dialog--active').exists()).toBe(false);
+    expect(wrapper.find('.v-overlay--active').exists()).toBe(false);
   });
 
   it('is renered after showDialog', () => {
     store.commit('dialog/showDialog', {});
     const wrapper = mountDialog({});
-    expect(wrapper.get('.v-dialog--active'));
+    expect(wrapper.get('.v-overlay--active'));
   });
 
   it('renders correct title and text', () => {
@@ -63,9 +63,9 @@ describe('Dialog', () => {
     store.commit('dialog/showDialog', { title: 'Title', text: 'Text' });
     const wrapper = mountDialog({});
 
-    expect(wrapper.find('.v-dialog--active').exists()).toBe(true);
+    expect(wrapper.find('.v-overlay--active').exists()).toBe(true);
     await wrapper.get('#confirm_btn').trigger('click');
-    expect(wrapper.find('.v-dialog--active').exists()).toBe(false);
+    expect(wrapper.find('.v-overlay--active').exists()).toBe(false);
   });
 
   it('triggers action on button click', async () => {

--- a/tests/unit/persistent_dialog_tests.spec.js
+++ b/tests/unit/persistent_dialog_tests.spec.js
@@ -43,22 +43,22 @@ describe('PersistentDialog', () => {
 
   it('not renered by default', () => {
     const wrapper = mountDialog({});
-    expect(wrapper.find('.v-dialog--active').exists()).toBe(false);
+    expect(wrapper.find('.v-overlay--active').exists()).toBe(false);
   });
 
   it('is renered after showPersistentDialog', () => {
     store.commit('persistentDialog/showPersistentDialog', {});
     const wrapper = mountDialog({});
-    expect(wrapper.get('.v-dialog--active'));
+    expect(wrapper.get('.v-overlay--active'));
   });
 
   it('disappears after hidePersistentDialog', async () => {
     store.commit('persistentDialog/showPersistentDialog', {});
     const wrapper = mountDialog({});
-    expect(wrapper.get('.v-dialog--active'));
+    expect(wrapper.get('.v-overlay--active'));
     store.commit('persistentDialog/hidePersistentDialog', {});
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('.v-dialog--active').exists()).toBe(false);
+    expect(wrapper.find('.v-overlay--active').exists()).toBe(false);
   });
 
   it('renders correct text', () => {


### PR DESCRIPTION
v-dialog seems to still have bugs related to not properly
removing the overlay if it's closed very quickly after being
opened.
See: https://github.com/vuetifyjs/vuetify/issues/8625
and https://github.com/vuetifyjs/vuetify/issues/9588

Though these bugs are apparently closed, I suspect the underlying
issue is still there, causing v-dialog to not remove the overlay.
The workaround submitted here is to not use v-dialog, but instead
use v-overlay directly (which doesn't have an animation).

Also, change a default in toast.store.js to 0 from 2000 (2000
didn't make sense).