### PR TITLE
Fix marker map on firefox, fix reference to missing kmlPoints

### DIFF
--- a/src/components/LobbyOptions.vue
+++ b/src/components/LobbyOptions.vue
@@ -40,8 +40,8 @@
           <div
             v-if="
               gameMode == 'rendezvous' &&
-              selectedShapeNames.length == 0 &&
-              kmlPoints.length == 0
+                selectedShapeNames.length == 0 &&
+                kmlPointCount == 0
             "
           >
             <span class="red--text">Warning:</span> for rendezvous to be

--- a/src/views/ClassicGame.vue
+++ b/src/views/ClassicGame.vue
@@ -86,14 +86,11 @@
   width: 400px;
   height: 200px;
   left: 0;
-
   bottom: 0;
   background-color: rgba(145, 10, 172, 0.5);
   z-index: 2;
   cursor: pointer;
   display: block;
-  scale: 0.5;
-
   transition: all 0.2s ease-in-out;
 }
 

--- a/src/views/RendezvousGame.vue
+++ b/src/views/RendezvousGame.vue
@@ -121,14 +121,11 @@
   width: 400px;
   height: 200px;
   left: 0;
-
   bottom: 0;
   background-color: rgba(145, 10, 172, 0.5);
   z-index: 2;
   cursor: pointer;
   display: block;
-  scale: 0.5;
-
   transition: all 0.2s ease-in-out;
 }
 


### PR DESCRIPTION
This change removes the "scale: 0.5" css property from the marker
map. It seems to have no effect on chrome, but makes the map smaller
(and unusable in other ways) on at least firefox.
Also fixes a minor bug where the template depends on kmlPoints,
instead of kmlPointCount.