### PR TITLE
Rendezvous fixes

### DIFF
--- a/src/components/MarkerMap.vue
+++ b/src/components/MarkerMap.vue
@@ -141,13 +141,16 @@ export default {
             strokeColor: beacon.in_range ? colors.blue.base : colors.grey.base,
             fillColor: beacon.in_range ? colors.blue.base : colors.grey.base,
           });
-          // TODO: instead of using the chart API, we should have static pins (maybe SVG) to make the rendering
-          // less laggy. The chart API means we redownload the icons frequently. This will also help (probably)
+          // TODO: instead of using the chart API, we should have static pins
+          // (maybe SVG) to make the rendering less laggy. The chart API means
+          // we redownload the icons frequently. This will also help (probably)
           // make the pins within streetview appear more reliably.
           // TODO: test playability on a non-monster laptop.
           this.mapBeacons[id].marker.setOptions({
             clickable: beacon.connected,
-            icon: `https://chart.apis.google.com/chart?chst=d_map_pin_icon&chld=${marker_icon}|${marker_color}`,
+            icon:
+              'https://chart.apis.google.com/chart?chst=d_map_pin_icon' +
+              `&chld=${marker_icon}|${marker_color}`,
           });
           for (const [followup_id, followup] of Object.entries(
             beacon?.followups ?? {},
@@ -159,6 +162,9 @@ export default {
                 position: followup.position,
                 map: this.map,
                 clickable: false,
+                icon:
+                  'https://chart.apis.google.com/chart?chst=d_map_pin_icon' +
+                  `&chld=glyphish_lock|${colors.grey.base.substr(1)}`,
               });
             }
             if (
@@ -195,7 +201,9 @@ export default {
           marker: new google.maps.Marker({
             position: beacon.position,
             map: this.map,
-            icon: `https://chart.apis.google.com/chart?chst=d_map_pin_icon&chld=${marker_icon}|${marker_color}`,
+            icon:
+              'https://chart.apis.google.com/chart?chst=d_map_pin_icon' +
+              `&chld=${marker_icon}|${marker_color}`,
             clickable: beacon.connected,
           }),
           followups: {},

--- a/src/components/Streets.vue
+++ b/src/components/Streets.vue
@@ -146,6 +146,10 @@ export default {
       type: Object,
       required: true,
     },
+    triggerTeleportToPanoramaId: {
+      type: Object,
+      required: false,
+    },
     backToStartEnabled: {
       type: Boolean,
       required: true,
@@ -279,18 +283,13 @@ export default {
         }
         this.undoPanoramaId = this.currentPanoramaId;
         this.currentPanoramaId = panoramaId;
+        this.$emit('pano_changed', panoramaId);
       });
       this.panorama.addListener('position_changed', () => {
         this.mapPosition = this.panorama.getPosition().toJSON();
       });
     },
     refreshMarkers: function() {
-      //if (Object.values(this.currentMarkers).length != 0) {
-      //  console.error(this.currentMarkers.length);
-      //  return;
-      //}
-      //this.wipeCurrentMarkers();
-      // TODO: use streetview APIs to reposition pins, rather than regenerating them.
       for (const [player_uuid, marker_info] of Object.entries(
         this.playerMarkers,
       )) {
@@ -346,6 +345,9 @@ export default {
               const followup_obj = new google.maps.Marker({
                 position: followup.position,
                 map: this.panorama,
+                icon:
+                  'https://chart.apis.google.com/chart?chst=d_map_pin_icon' +
+                  `&chld=glyphish_lock|${colors.grey.base.substr(1)}`,
               });
               this.mapBeaconMarkers[beacon_uuid].followups[
                 followup_uuid
@@ -377,6 +379,17 @@ export default {
         newValue,
       );
       this.panorama.setPosition(newValue);
+    },
+    triggerTeleportToPanoramaId: function(newValue) {
+      if (newValue.panoramaId == '') {
+        return;
+      }
+      this.ensureStreetviewLoaded(newValue);
+      console.log(
+        'triggerTeleportToPanoramaId changed, forcing streetview panorama to: ',
+        newValue,
+      );
+      this.panorama.setPano(newValue.panoramaId);
     },
     mapPosition: function(newValue, oldValue) {
       if (newValue?.lat == null || newValue?.lng == null) {

--- a/src/game_gen/game_generator.js
+++ b/src/game_gen/game_generator.js
@@ -110,7 +110,7 @@ export class GameGenerator {
   }
 
   async generateValidPositionFromKmlPoints() {
-    while (true) {
+    for (let i = 0; i < 60; i++) {
       if (this.kmlPoints.length == 0) {
         return null;
       }
@@ -231,7 +231,6 @@ export class GameGenerator {
       victory: false,
       finished: false,
     };
-    console.error('write', rendezvous_data);
 
     if (this.cancelled) throw new CancelledError();
 


### PR DESCRIPTION
Replace locked beacon markers to make them less similar to the guess markers. Clicking beacon now teleports to panorama, rather than position. Sample followups from roughly previous beacon's range.